### PR TITLE
Replace BeautifulSoup prettify() with lxml for robust HTML formatting

### DIFF
--- a/library/html_util.py
+++ b/library/html_util.py
@@ -8,8 +8,36 @@ import pyperclip
 import yaml
 from bs4 import BeautifulSoup
 from flask import request
+from lxml import html as lxml_html
 
 from library import docker_util, img_util, url_util
+
+
+def prettify_html(html_text: str) -> str:
+    """Pretty-print HTML using lxml to avoid BeautifulSoup prettify issues.
+
+    BeautifulSoup's prettify() can produce invalid HTML in certain cases,
+    particularly around self-closing tags, void elements, and script content.
+    This function uses lxml for robust pretty-printing.
+
+    Args:
+        html_text: Raw HTML string to prettify
+
+    Returns:
+        Prettified HTML string. If parsing fails, returns original text.
+    """
+    if not html_text or not isinstance(html_text, str):
+        return html_text
+
+    try:
+        root = lxml_html.fromstring(html_text)
+        return lxml_html.tostring(
+            root,
+            pretty_print=True,
+            encoding="unicode"
+        )
+    except Exception:
+        return html_text
 
 FAVICON_WIDTH = 20
 
@@ -148,8 +176,7 @@ def get_page_metadata(
 
     # Prettify HTML
     if meta.html:
-        soup = BeautifulSoup(meta.html, "html.parser")
-        meta.html = soup.prettify()
+        meta.html = prettify_html(meta.html)
 
     # Extract favicon links from the HTML page sorted by optimal size.
     favicon_links = get_favicon_links(meta.url, meta.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11,<3.12"
 
 dependencies = [
     "beautifulsoup4>=4.12.3",
+    "lxml>=5.0.0",
     "markdown>=3.7",
     "flask>=3.1.0",
     "requests>=2.32.3",

--- a/web-tool.py
+++ b/web-tool.py
@@ -184,7 +184,7 @@ def mirror_html_source():
     # If clip is valid JSON, extract the HTML and prettify it.
     html_text = ""
     if metadata.soup:
-        html_text = metadata.soup.prettify()
+        html_text = html_util.prettify_html(str(metadata.soup))
         return util.plain_text_response(
             template_env,
             "HTML Source",


### PR DESCRIPTION
BeautifulSoup's prettify() can produce invalid HTML around self-closing tags, void elements, and script content. This change:

- Adds lxml>=5.0.0 dependency
- Creates new prettify_html() function in html_util.py using lxml
- Updates get_page_metadata() to use the new function
- Updates mirror_html_source() endpoint to use html_util.prettify_html()

The new function includes fallback to original text on parse failure.