### PR TITLE
Add inline base64 favicon support with height-based sizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ venv.bak/
 local-cache/
 .env
 uv.lock
+.factory/
+.remember/

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -452,7 +452,7 @@ The favicon system uses a three-tier hierarchical cache:
    - Manual customizations edited by users
    - Domain-level: `example.com: https://example.com/favicon.ico`
    - Path-level: `example.com/docs: https://example.com/docs/favicon.ico`
-   - Inline format: `example.com: {url: "https://...", inline: "data:image/png;base64,..."}`
+   - Inline format: `example.com: {url: "https://...", inline_image: "data:image/png;base64,..."}`
    - The inline format stores a pre-sized (height=20) base64-encoded PNG for optimal link size
 
 2. **App Defaults** (`static/favicon.yml`) — Medium priority

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -433,6 +433,11 @@ For each segment, displays:
 - If no favicon cached: Automatically caches the top favicon for future use
 - Uses [favicon cache system](#favicon-system) with three-tier priority
 
+**Favicon Display:**
+- Favicon images use `height="20"` with aspect ratio preserved
+- Inline base64 option shown only when favicon is stored with inline data in cache
+- URL option copies just the URL; Inline option copies full `<img>` tag with base64 data
+
 **Implementation:** [web-tool.py](web-tool.py) - `get_mirror_links()` function; [library/util.py](library/util.py) - `TitleVariants` class; [library/url_util.py](library/url_util.py) - URL parsing functions
 
 ---
@@ -447,6 +452,8 @@ The favicon system uses a three-tier hierarchical cache:
    - Manual customizations edited by users
    - Domain-level: `example.com: https://example.com/favicon.ico`
    - Path-level: `example.com/docs: https://example.com/docs/favicon.ico`
+   - Inline format: `example.com: {url: "https://...", inline: "data:image/png;base64,..."}`
+   - The inline format stores a pre-sized (height=20) base64-encoded PNG for optimal link size
 
 2. **App Defaults** (`static/favicon.yml`) — Medium priority
    - Pre-configured favicons distributed with the application
@@ -500,7 +507,13 @@ Each favicon shows which cache file it comes from:
 **User Interface Elements:**
 - "Add to Overrides" button available for each favicon
 - Scope selector: Domain-level or Path-level override
+- "Save as inline" checkbox: Stores favicon as pre-sized (height=20) base64-encoded inline image
 - Real-time cache update feedback
+
+**mirror-favicons Page Display:**
+- INLINE badge shown for favicons stored with inline base64 data
+- Favicon previews use `height="20"` (aspect ratio preserved)
+- Shows both URL preview and inline base64 preview when available
 
 **Implementation:** [web-tool.py](web-tool.py) - `get_mirror_favicons()` function; [library/html_util.py](library/html_util.py) - `get_favicon_links()`, `sort_favicon_links()`, `add_favicon_to_cache()` functions
 
@@ -514,6 +527,7 @@ Each favicon shows which cache file it comes from:
 - `favicon_url` (required): URL of the favicon to cache
 - `page_url` (required): URL of the page (used to determine cache key)
 - `scope` (optional, default: `domain`): Cache scope - `domain` or `path`
+- `save_inline` (optional, default: `false`): If `true`, stores favicon as inline base64 (pre-sized to height=20)
 
 **Response (JSON):**
 
@@ -537,6 +551,7 @@ Each favicon shows which cache file it comes from:
 - Parses `page_url` to extract domain (and path if scope=`path`)
 - Normalizes domain by removing `www.` prefix
 - Loads existing overrides from `static/favicon-overrides.yml`
+- If `save_inline` is `true`, fetches the favicon image, resizes to height=20 (preserving aspect ratio), and stores as base64-encoded inline data
 - Adds/updates the new override
 - Writes file back, preserving header comments and YAML formatting
 - Invalidates in-memory cache to force reload on next request

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -16,12 +16,12 @@ tests/
 ├── test_unicode_util.py         # Unicode utility tests (~20 tests)
 ├── test_text_util.py            # Text processing tests (~30 tests)
 ├── test_url_util.py             # URL parsing tests (~15 tests)
-├── test_html_util.py            # HTML/favicon tests (~20 tests)
+├── test_html_util.py            # HTML/favicon tests (~35 tests)
 ├── test_docker_util.py          # Container detection tests (~15 tests)
-└── test_img_util.py             # Image conversion tests (~20 tests)
+└── test_img_util.py             # Image conversion tests (~30 tests)
 ```
 
-**Total: ~160+ test cases across 8 test modules**
+**Total: ~210+ test cases across 8 test modules**
 
 ## Module-by-Module Coverage
 
@@ -83,7 +83,7 @@ tests/
 - HTTPS/HTTP protocol handling
 - Error handling and defaults
 
-### 4. `test_html_util.py` (~20 tests)
+### 4. `test_html_util.py` (~35 tests)
 **Purpose:** Test HTML parsing, favicon discovery, and metadata
 
 **Test Classes:**
@@ -92,12 +92,17 @@ tests/
 - `TestFaviconCacheStructure` (3 tests) - Cache path configuration
 - `TestRelLinkValidation` (5 tests) - Link validation logic
 - `TestRelLinkComparison` (3 tests) - Link comparison
+- `TestRelLinkInlineImage` (3 tests) - inline_image field handling
+- `TestGetFaviconCacheDictFormat` (3 tests) - Dict-format cache entries
+- `TestGetFaviconCacheSource` (3 tests) - Cache source detection with dict format
 
 **Coverage:**
 - Favicon link representation and validation
 - Cache configuration (overrides, defaults, auto-discovered)
 - Link metadata (rel, sizes, dimensions)
 - Favicon constants and paths
+- Inline base64 image storage in cache
+- Dict-format cache entry handling
 
 ### 5. `test_docker_util.py` (~15 tests)
 **Purpose:** Test container detection logic
@@ -120,7 +125,7 @@ tests/
 - Exception handling for missing/unreadable files
 - Integration with actual system
 
-### 6. `test_img_util.py` (~20 tests)
+### 6. `test_img_util.py` (~30 tests)
 **Purpose:** Test image conversion utilities
 
 **Test Classes:**
@@ -129,6 +134,8 @@ tests/
 - `TestConvertSvg` (8 tests) - SVG to PNG conversion
 - `TestImageConversionIntegration` (4 tests) - Integration tests
 - `TestImageConversionEdgeCases` (4 tests) - Edge cases
+- `TestEncodeFaviconInline` (10 tests) - Favicon inline base64 encoding
+- `TestEncodeFaviconInlineIntegration` (2 tests) - Integration tests
 
 **Coverage:**
 - Function signatures and parameters
@@ -136,6 +143,7 @@ tests/
 - Error handling (network errors, invalid formats)
 - Format conversion options
 - Empty and malformed input handling
+- Favicon inline base64 encoding with height-based resizing
 
 ### 7. `test_title_variants.py` (~40 tests)
 **Purpose:** Test title variant generation (existing tests)

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -288,6 +288,9 @@ def get_favicon_cache(page_url) -> RelLink:
                     # New format: {'url': url, 'inline_image': inline_data}
                     href = cached.get("url", "")
                     inline_image = cached.get("inline_image", None)
+                    # Skip entries with missing or empty URL
+                    if not href:
+                        continue
                 else:
                     # Legacy format: plain URL string
                     href = cached

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -261,16 +261,21 @@ def get_favicon_cache(page_url) -> RelLink:
     search_paths = []
     parsed = urlparse(page_url)
 
+    # Normalize netloc by stripping www. prefix for consistent matching
+    netloc = parsed.netloc
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+
     # Get the first part of the path.
     path_part = parsed.path
     if path_part.startswith("/"):
         path_part = path_part[1:]
     if len(path_part) > 0:
         path_part = path_part.split("/")[0]
-        search_paths.append(f"{parsed.netloc}/{path_part}")
+        search_paths.append(f"{netloc}/{path_part}")
 
     # Split the netloc into parts and add paths until there are just two parts.
-    tokens = parsed.netloc.split(".")
+    tokens = netloc.split(".")
     while len(tokens) > 1:
         search_paths.append(".".join(tokens))
         tokens.pop(0)
@@ -333,16 +338,21 @@ def get_favicon_cache_source(page_url: str, favicon_href: str) -> dict:
     search_paths = []
     parsed = urlparse(page_url)
 
+    # Normalize netloc by stripping www. prefix for consistent matching
+    netloc = parsed.netloc
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+
     # Get the first part of the path
     path_part = parsed.path
     if path_part.startswith("/"):
         path_part = path_part[1:]
     if len(path_part) > 0:
         path_part = path_part.split("/")[0]
-        search_paths.append(f"{parsed.netloc}/{path_part}")
+        search_paths.append(f"{netloc}/{path_part}")
 
     # Split the netloc into parts and add paths until there are just two parts
-    tokens = parsed.netloc.split(".")
+    tokens = netloc.split(".")
     while len(tokens) > 1:
         search_paths.append(".".join(tokens))
         tokens.pop(0)

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -31,15 +31,12 @@ def prettify_html(html_text: str) -> str:
 
     try:
         root = lxml_html.fromstring(html_text)
-        return lxml_html.tostring(
-            root,
-            pretty_print=True,
-            encoding="unicode"
-        )
+        return lxml_html.tostring(root, pretty_print=True, encoding="unicode")
     except Exception:
         return html_text
 
-FAVICON_WIDTH = 20
+
+FAVICON_HEIGHT = 20
 
 # Three-tier favicon cache system:
 # 1. User overrides (highest priority) - manual customizations
@@ -94,6 +91,7 @@ class RelLink:
     height: int = 0
     width: int = 0
     image_type: str = None
+    inline_image: str = None
     _validated: bool = False
 
     def validate(self) -> bool:
@@ -141,7 +139,7 @@ class PageMetadata:
 
 
 def get_page_metadata(
-    meta: PageMetadata = None, max_favicon_links: int = 1, favicon_width: int = FAVICON_WIDTH
+    meta: PageMetadata = None, max_favicon_links: int = 1, favicon_height: int = FAVICON_HEIGHT
 ) -> PageMetadata:
     """Add metadata to PageMetadata object."""
 
@@ -180,7 +178,7 @@ def get_page_metadata(
 
     # Extract favicon links from the HTML page sorted by optimal size.
     favicon_links = get_favicon_links(meta.url, meta.html)
-    sorted_links = sort_favicon_links(favicon_links, favicon_width, max_favicon_links)
+    sorted_links = sort_favicon_links(favicon_links, favicon_height, max_favicon_links)
 
     # Validate only the top candidates (lazy validation)
     meta.favicons = validate_top_candidates(sorted_links, max_count=max_favicon_links)
@@ -284,11 +282,22 @@ def get_favicon_cache(page_url) -> RelLink:
         (discovered_cache, "discovered"),
     ]:
         for s in search_paths:
-            if favicon := cache_dict.get(s):
+            if cached := cache_dict.get(s):
+                # Handle both string and dict cache formats
+                if isinstance(cached, dict):
+                    # New format: {'url': url, 'inline': inline_data}
+                    href = cached.get("url", "")
+                    inline_image = cached.get("inline", None)
+                else:
+                    # Legacy format: plain URL string
+                    href = cached
+                    inline_image = None
+
                 # Cached favicons are pre-validated, no HTTP check needed
-                r = RelLink(favicon, cache_key=s)
+                r = RelLink(href, cache_key=s)
                 r._validated = True
-                r.resolved_href = favicon
+                r.resolved_href = href
+                r.inline_image = inline_image
                 # Mark as valid by setting a reasonable default type
                 r.image_type = "image/png"
                 return r
@@ -343,8 +352,13 @@ def get_favicon_cache_source(page_url: str, favicon_href: str) -> dict:
     ]:
         for search_path in search_paths:
             if cached_favicon := cache_dict.get(search_path):
+                # Handle both string and dict cache formats
+                if isinstance(cached_favicon, dict):
+                    cached_url = cached_favicon.get("url", "")
+                else:
+                    cached_url = cached_favicon
                 # Check if this cached favicon matches the one we're looking for
-                if cached_favicon == favicon_href:
+                if cached_url == favicon_href:
                     return {"file": cache_file, "cache_key": search_path, "precedence": precedence}
 
     # Not found in any cache
@@ -533,7 +547,7 @@ def get_common_favicon_links(page_url):
 
 
 def sort_favicon_links(
-    favicons: list[RelLink], favicon_width: int = FAVICON_WIDTH, include: str = None
+    favicons: list[RelLink], favicon_height: int = FAVICON_HEIGHT, include: str = None
 ) -> list[RelLink]:
     """Sort favicons to prefer those closest to target size.
 
@@ -550,7 +564,7 @@ def sort_favicon_links(
 
     Args:
         favicons: List of favicon links to sort
-        favicon_width: Target width in pixels (default: 20)
+        favicon_height: Target height in pixels (default: 20)
         include: If "all", include all favicons; otherwise return only best match
 
     Returns:
@@ -575,8 +589,8 @@ def sort_favicon_links(
         "svg-conversion": 100,
     }
 
-    # Target area for optimal favicon size
-    target_area = favicon_width * favicon_width
+    # Target area for optimal favicon size (based on height)
+    target_area = favicon_height * favicon_height
 
     # Define a key function that returns the sorting key.
     def key_fn(x: RelLink):

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -285,9 +285,9 @@ def get_favicon_cache(page_url) -> RelLink:
             if cached := cache_dict.get(s):
                 # Handle both string and dict cache formats
                 if isinstance(cached, dict):
-                    # New format: {'url': url, 'inline': inline_data}
+                    # New format: {'url': url, 'inline_image': inline_data}
                     href = cached.get("url", "")
-                    inline_image = cached.get("inline", None)
+                    inline_image = cached.get("inline_image", None)
                 else:
                     # Legacy format: plain URL string
                     href = cached

--- a/library/img_util.py
+++ b/library/img_util.py
@@ -84,7 +84,8 @@ def encode_favicon_inline(href: str, target_height: int = 20) -> str | None:
     """Encode a favicon as a base64 PNG string, resized to target height.
 
     Fetches the image from href, resizes to target_height preserving aspect
-    ratio, and returns base64-encoded PNG data URL.
+    ratio, and returns base64-encoded PNG data URL. Width is clamped to
+    max 20x the target height to prevent huge base64 strings.
 
     Args:
         href: URL of the favicon image
@@ -104,6 +105,13 @@ def encode_favicon_inline(href: str, target_height: int = 20) -> str | None:
         aspect_ratio = img.width / img.height
         new_height = target_height
         new_width = int(target_height * aspect_ratio)
+
+        # Clamp width to prevent huge base64 strings from very wide images
+        # Most favicons have reasonable aspect ratios; limit to 20x the height
+        MAX_WIDTH = target_height * 20
+        if new_width > MAX_WIDTH:
+            new_width = MAX_WIDTH
+            new_height = int(MAX_WIDTH / aspect_ratio)
 
         # Resize using high-quality resampling
         resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)

--- a/library/img_util.py
+++ b/library/img_util.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 from functools import lru_cache
 from io import BytesIO
@@ -75,4 +76,46 @@ def convert_svg(href: str, to_format: str = "PNG") -> bytes:
         return png_buffer.getvalue()
     except Exception as e:
         logging.warning(f"Not an SVG file: {href} {e}")
+        return None
+
+
+@lru_cache(maxsize=128)
+def encode_favicon_inline(href: str, target_height: int = 20) -> str | None:
+    """Encode a favicon as a base64 PNG string, resized to target height.
+
+    Fetches the image from href, resizes to target_height preserving aspect
+    ratio, and returns base64-encoded PNG data URL.
+
+    Args:
+        href: URL of the favicon image
+        target_height: Target height in pixels (default: 20)
+
+    Returns:
+        Base64-encoded PNG string (with data URL prefix) or None on failure
+    """
+    try:
+        resp = url_util.get_url(href)
+        resp.raise_for_status()
+
+        # Open the image
+        img = Image.open(BytesIO(resp.content))
+
+        # Calculate new dimensions preserving aspect ratio
+        aspect_ratio = img.width / img.height
+        new_height = target_height
+        new_width = int(target_height * aspect_ratio)
+
+        # Resize using high-quality resampling
+        resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+
+        # Convert to PNG and encode as base64
+        png_buffer = BytesIO()
+        resized.save(png_buffer, format="PNG")
+        png_bytes = png_buffer.getvalue()
+
+        # Encode as base64 with data URL prefix
+        b64 = base64.b64encode(png_bytes).decode("ascii")
+        return f"data:image/png;base64,{b64}"
+    except Exception as e:
+        logging.warning(f"Failed to encode favicon inline: {href} {e}")
         return None

--- a/templates/mirror-favicons.html
+++ b/templates/mirror-favicons.html
@@ -8,13 +8,14 @@
         function addOverride(faviconHref, pageUrl, formId) {
             const form = document.getElementById(formId);
             const scope = form.querySelector('input[name="scope"]:checked').value;
+            const saveInline = form.querySelector('input[name="save_inline"]').checked;
             const messageEl = form.querySelector('.override-message');
             const button = form.querySelector('button');
-            
+
             button.disabled = true;
             messageEl.textContent = 'Adding override...';
             messageEl.className = 'override-success';
-            
+
             fetch('/add-favicon-override', {
                 method: 'POST',
                 headers: {
@@ -23,7 +24,8 @@
                 body: JSON.stringify({
                     favicon_url: faviconHref,
                     page_url: pageUrl,
-                    scope: scope
+                    scope: scope,
+                    save_inline: saveInline
                 })
             })
             .then(resp => resp.json())
@@ -89,6 +91,9 @@
             {% if f.cache_source.file %}
                 {% if f.cache_source.file == 'override' %}
                     <span class="cache-badge cache-override">OVERRIDE</span>
+                    {% if f.inline_image %}
+                    <span class="cache-badge cache-override">INLINE</span>
+                    {% endif %}
                 {% elif f.cache_source.file == 'default' %}
                     <span class="cache-badge cache-default">DEFAULT</span>
                 {% elif f.cache_source.file == 'discovered' %}
@@ -112,8 +117,13 @@
         
         {% if f.image_type != 'invalid' %}
         <p>
-            <img src="{{ f.href }}" width="20" alt="20x20 preview" /> 20x20 preview
+            <img src="{{ f.href }}" height="20" alt="20px height preview" /> 20px height preview
         </p>
+        {% if f.inline_image %}
+        <p>
+            <img src="{{ f.inline_image }}" alt="Inline preview" /> Inline (base64, 20px height)
+        </p>
+        {% endif %}
         <p>
             <img src="{{ f.href }}" alt="Full size"/> Full size ({{ f.width }}x{{ f.height }})
         </p>
@@ -134,6 +144,10 @@
                 Domain + first path ({{ url.split('/')[2] }}/{{ url.split('/')[3] }})
             </label>
             {% endif %}
+            <label>
+                <input type="checkbox" name="save_inline">
+                Save as inline (base64)
+            </label>
             <button onclick="addOverride('{{ f.href|e }}', '{{ url|e }}', 'form-{{ loop.index }}')">
                 Add to Overrides
             </button>

--- a/templates/mirror-favicons.html
+++ b/templates/mirror-favicons.html
@@ -91,13 +91,13 @@
             {% if f.cache_source.file %}
                 {% if f.cache_source.file == 'override' %}
                     <span class="cache-badge cache-override">OVERRIDE</span>
-                    {% if f.inline_image %}
-                    <span class="cache-badge cache-override">INLINE</span>
-                    {% endif %}
                 {% elif f.cache_source.file == 'default' %}
                     <span class="cache-badge cache-default">DEFAULT</span>
                 {% elif f.cache_source.file == 'discovered' %}
                     <span class="cache-badge cache-discovered">DISCOVERED</span>
+                {% endif %}
+                {% if f.inline_image %}
+                <span class="cache-badge cache-override">INLINE</span>
                 {% endif %}
                 <span class="cache-key-info">cached as: {{ f.cache_source.cache_key }}</span>
             {% else %}

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -86,20 +86,21 @@
                 <input type="radio" name="favicon_option" value="none">
                 <span style="min-width: 100px;"><strong>None</strong></span>
             </div>
+            {% if favicon_inline %}
+            <div class="url-item">
+                <input type="radio" name="favicon_option" value="inline" checked>
+                <button class="copy-btn" data-html="&lt;img src=&quot;{{ favicon_inline|e }}&quot; height=&quot;20&quot; alt=&quot;Favicon&quot; /&gt;">Copy</button>
+                <span style="min-width: 100px;"><strong>Inline</strong></span>
+                <img src="{{ favicon_inline }}" height="20" alt="Favicon" />
+                <span>{{ favicon_inline|e }}</span>
+            </div>
+            {% else %}
             <div class="url-item">
                 <input type="radio" name="favicon_option" value="url" checked>
                 <button class="copy-btn" data-html="{{ favicon|e }}">Copy</button>
                 <span style="min-width: 100px;"><strong>URL</strong></span>
                 <img src="{{ favicon }}" height="20" alt="Favicon" />
                 <span><a href="{{ favicon|e }}">{{ favicon|e }}</a></span>
-            </div>
-            {% if favicon_inline %}
-            <div class="url-item">
-                <input type="radio" name="favicon_option" value="inline">
-                <button class="copy-btn" data-html="&lt;img src=&quot;{{ favicon_inline|e }}&quot; height=&quot;20&quot; alt=&quot;Favicon&quot; /&gt;">Copy</button>
-                <span style="min-width: 100px;"><strong>Inline</strong></span>
-                <img src="{{ favicon_inline }}" height="20" alt="Favicon" />
-                <span>{{ favicon_inline|e }}</span>
             </div>
             {% endif %}
         </div>
@@ -150,7 +151,7 @@
             title: defaultValues.title,
             fragmentText: '',
             url: '',
-            faviconOption: defaultValues.faviconInline ? 'inline' : 'url'
+            faviconOption: 'url'  // Will be overridden by DOMContentLoaded from checked radio
         };
 
         // Function to escape HTML for display

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -142,7 +142,7 @@
             fragmentText: {% if fragment %}'{{ fragment_text|e }}'{% else %}''{% endif %},
             url: '{{ url_variants[0].url|e }}',
             favicon: {% if favicon %}'{{ favicon|e }}'{% else %}null{% endif %},
-            faviconInline: {% if favicon_inline %}'{{ favicon_inline|e }}'{% else %}null{% endif %}
+            faviconInline: {% if favicon_inline %}{{ favicon_inline|tojson }}{% else %}null{% endif %}
         };
 
         // State tracking

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -81,11 +81,27 @@
     {% if favicon %}
     <div class="favicon-section">
         <h2>Favicon</h2>
-        <div class="favicon-display">
-            <input type="checkbox" id="include_favicon" checked>
-            <img src="{{ favicon }}" width="20" alt="Favicon" data-url="{{ favicon|e }}" />
-            <button class="copy-btn" data-html="{{ favicon|e }}">Copy</button>
-            <a href="{{ favicon }}">{{ favicon|e }}</a>
+        <div class="url-list">
+            <div class="url-item">
+                <input type="radio" name="favicon_option" value="none">
+                <span style="min-width: 100px;"><strong>None</strong></span>
+            </div>
+            <div class="url-item">
+                <input type="radio" name="favicon_option" value="url" checked>
+                <button class="copy-btn" data-html="{{ favicon|e }}">Copy</button>
+                <span style="min-width: 100px;"><strong>URL</strong></span>
+                <img src="{{ favicon }}" height="20" alt="Favicon" />
+                <span><a href="{{ favicon|e }}">{{ favicon|e }}</a></span>
+            </div>
+            {% if favicon_inline %}
+            <div class="url-item">
+                <input type="radio" name="favicon_option" value="inline">
+                <button class="copy-btn" data-html="&lt;img src=&quot;{{ favicon_inline|e }}&quot; height=&quot;20&quot; alt=&quot;Favicon&quot; /&gt;">Copy</button>
+                <span style="min-width: 100px;"><strong>Inline</strong></span>
+                <img src="{{ favicon_inline }}" height="20" alt="Favicon" />
+                <span>{{ favicon_inline|e }}</span>
+            </div>
+            {% endif %}
         </div>
     </div>
     {% endif %}
@@ -125,7 +141,8 @@
             title: '{{ title_variants[0].value|e }}',
             fragmentText: {% if fragment %}'{{ fragment_text|e }}'{% else %}''{% endif %},
             url: '{{ url_variants[0].url|e }}',
-            favicon: {% if favicon %}'{{ favicon|e }}'{% else %}null{% endif %}
+            favicon: {% if favicon %}'{{ favicon|e }}'{% else %}null{% endif %},
+            faviconInline: {% if favicon_inline %}'{{ favicon_inline|e }}'{% else %}null{% endif %}
         };
 
         // State tracking
@@ -133,7 +150,7 @@
             title: defaultValues.title,
             fragmentText: '',
             url: '',
-            favicon: true
+            faviconOption: defaultValues.faviconInline ? 'inline' : 'url'
         };
 
         // Function to escape HTML for display
@@ -144,12 +161,14 @@
         }
 
         // Function to build a link
-        function buildLink(title, fragmentText, url, includeFavicon) {
+        function buildLink(title, fragmentText, url, faviconOption) {
             let html = '';
 
             // Add favicon if requested
-            if (includeFavicon && defaultValues.favicon) {
-                html += `<img src="${escapeHtml(defaultValues.favicon)}" width="20" alt="Favicon" /> `;
+            if (faviconOption === 'inline' && defaultValues.faviconInline) {
+                html += `<img src="${escapeHtml(defaultValues.faviconInline)}" height="20" alt="Favicon" /> `;
+            } else if (faviconOption === 'url' && defaultValues.favicon) {
+                html += `<img src="${escapeHtml(defaultValues.favicon)}" height="20" alt="Favicon" /> `;
             }
 
             // Add link with appropriate text
@@ -161,7 +180,7 @@
 
         // Function to render the current state to the DOM
         function render() {
-            const activeLink = buildLink(state.title, state.fragmentText, state.url, state.favicon);
+            const activeLink = buildLink(state.title, state.fragmentText, state.url, state.faviconOption);
 
             // Update display elements
             document.getElementById('main-link-display').innerHTML = activeLink;
@@ -222,8 +241,8 @@
             const urlRadio = document.querySelector('input[name="url_variant"]:checked');
             state.url = urlRadio ? urlRadio.dataset.text : defaultValues.url;
 
-            const faviconCheckbox = document.getElementById('include_favicon');
-            state.favicon = faviconCheckbox ? faviconCheckbox.checked : false;
+            const faviconRadio = document.querySelector('input[name="favicon_option"]:checked');
+            state.faviconOption = faviconRadio ? faviconRadio.value : 'none';
 
             // Initial render
             render();
@@ -251,8 +270,8 @@
                         state.fragmentText = input.dataset.text;
                     } else if (input.name === 'url_variant') {
                         state.url = input.dataset.text;
-                    } else if (input.id === 'include_favicon') {
-                        state.favicon = input.checked;
+                    } else if (input.name === 'favicon_option') {
+                        state.faviconOption = input.value;
                     }
                     render();
                 });

--- a/tests/test_html_util.py
+++ b/tests/test_html_util.py
@@ -242,7 +242,10 @@ class TestGetFaviconCacheDictFormat:
         # Setup mock to return dict-format entry with inline
         mock_load_cache.side_effect = [
             {
-                "example.com": {"url": "http://example.com/favicon.png", "inline": inline_data}
+                "example.com": {
+                    "url": "http://example.com/favicon.png",
+                    "inline_image": inline_data,
+                }
             },  # overrides_cache
             {},  # defaults_cache
             {},  # discovered_cache
@@ -305,7 +308,7 @@ class TestGetFaviconCacheSource:
             {},  # discovered_cache (called 1st)
             {},  # defaults_cache (called 2nd)
             {
-                "example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}
+                "example.com": {"url": "http://example.com/favicon.png", "inline_image": "data:xxx"}
             },  # overrides_cache (called 3rd)
         ]
 
@@ -327,7 +330,7 @@ class TestGetFaviconCacheSource:
             {},  # discovered_cache (called 1st)
             {},  # defaults_cache (called 2nd)
             {
-                "example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}
+                "example.com": {"url": "http://example.com/favicon.png", "inline_image": "data:xxx"}
             },  # overrides_cache (called 3rd)
         ]
 

--- a/tests/test_html_util.py
+++ b/tests/test_html_util.py
@@ -11,7 +11,7 @@ import pytest
 from library.html_util import (
     COMMON_FAVICON_FILES,
     FAVICON_REL,
-    FAVICON_WIDTH,
+    FAVICON_HEIGHT,
     ICO_TO_PNG_PATH,
     SVG_TO_PNG_PATH,
     RelLink,
@@ -90,9 +90,9 @@ class TestFaviconConstants:
         """Test that COMMON_FAVICON_FILES is a list."""
         assert isinstance(COMMON_FAVICON_FILES, list)
 
-    def test_favicon_width_is_positive(self):
-        """Test that FAVICON_WIDTH is positive."""
-        assert FAVICON_WIDTH > 0
+    def test_favicon_height_is_positive(self):
+        """Test that FAVICON_HEIGHT is positive."""
+        assert FAVICON_HEIGHT > 0
 
     def test_ico_to_png_path_is_string(self):
         """Test that ICO_TO_PNG_PATH is a string."""

--- a/tests/test_html_util.py
+++ b/tests/test_html_util.py
@@ -5,6 +5,7 @@ Tests HTML parsing, favicon discovery, and metadata extraction.
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -181,6 +182,149 @@ class TestRelLinkComparison:
         link1 = RelLink(href="http://example.com/favicon.ico", cache_key="example.com")
         link2 = RelLink(href="http://example.com/favicon.ico", cache_key="www.example.com")
         assert link1.cache_key != link2.cache_key
+
+
+class TestRelLinkInlineImage:
+    """Tests for RelLink inline_image field."""
+
+    def test_inline_image_defaults_to_none(self):
+        """Test that inline_image defaults to None."""
+        link = RelLink(href="http://example.com/favicon.ico")
+        assert link.inline_image is None
+
+    def test_inline_image_can_be_set(self):
+        """Test that inline_image can be set."""
+        link = RelLink(href="http://example.com/favicon.ico")
+        link.inline_image = "data:image/png;base64,abc123"
+        assert link.inline_image == "data:image/png;base64,abc123"
+
+    def test_inline_image_with_all_fields(self):
+        """Test initialization with inline_image."""
+        inline_data = "data:image/png;base64,xyz789"
+        link = RelLink(
+            href="http://example.com/favicon.ico",
+            cache_key="example.com",
+            height=20,
+            width=20,
+            image_type="image/png",
+            inline_image=inline_data,
+        )
+        assert link.inline_image == inline_data
+
+
+class TestGetFaviconCacheDictFormat:
+    """Tests for get_favicon_cache handling dict-format cache entries."""
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_with_string_entry(self, mock_load_cache):
+        """Test that string-format cache entries work correctly."""
+        from library.html_util import get_favicon_cache
+
+        # Setup mock to return string-format entry
+        mock_load_cache.side_effect = [
+            {},  # overrides_cache
+            {},  # defaults_cache
+            {"example.com": "http://example.com/favicon.ico"},  # discovered_cache
+        ]
+
+        result = get_favicon_cache("http://example.com/some/path")
+
+        assert result is not None
+        assert result.href == "http://example.com/favicon.ico"
+        assert result.inline_image is None
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_with_dict_entry(self, mock_load_cache):
+        """Test that dict-format cache entries with inline data work correctly."""
+        from library.html_util import get_favicon_cache
+
+        inline_data = "data:image/png;base64,abc123"
+        # Setup mock to return dict-format entry with inline
+        mock_load_cache.side_effect = [
+            {"example.com": {"url": "http://example.com/favicon.png", "inline": inline_data}},  # overrides_cache
+            {},  # defaults_cache
+            {},  # discovered_cache
+        ]
+
+        result = get_favicon_cache("http://example.com/some/path")
+
+        assert result is not None
+        assert result.href == "http://example.com/favicon.png"
+        assert result.inline_image == inline_data
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_with_dict_entry_no_inline(self, mock_load_cache):
+        """Test that dict-format entry without inline sets inline_image to None."""
+        from library.html_util import get_favicon_cache
+
+        # Setup mock to return dict-format entry without inline
+        mock_load_cache.side_effect = [
+            {"example.com": {"url": "http://example.com/favicon.png"}},  # overrides_cache
+            {},  # defaults_cache
+            {},  # discovered_cache
+        ]
+
+        result = get_favicon_cache("http://example.com/some/path")
+
+        assert result is not None
+        assert result.href == "http://example.com/favicon.png"
+        assert result.inline_image is None
+
+
+class TestGetFaviconCacheSource:
+    """Tests for get_favicon_cache_source handling dict-format cache entries."""
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_source_with_string_entry(self, mock_load_cache):
+        """Test that string-format cache entries work correctly."""
+        from library.html_util import get_favicon_cache_source
+
+        # Function calls loaders in order: discovered, defaults, overrides
+        mock_load_cache.side_effect = [
+            {"example.com": "http://example.com/favicon.ico"},  # discovered_cache (called 1st)
+            {},  # defaults_cache (called 2nd)
+            {},  # overrides_cache (called 3rd)
+        ]
+
+        result = get_favicon_cache_source("http://example.com/path", "http://example.com/favicon.ico")
+
+        assert result["file"] == "discovered"
+        assert result["precedence"] == 3
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_source_with_dict_entry(self, mock_load_cache):
+        """Test that dict-format cache entries match correctly."""
+        from library.html_util import get_favicon_cache_source
+
+        # Function calls loaders in order: discovered, defaults, overrides
+        mock_load_cache.side_effect = [
+            {},  # discovered_cache (called 1st)
+            {},  # defaults_cache (called 2nd)
+            {"example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}},  # overrides_cache (called 3rd)
+        ]
+
+        result = get_favicon_cache_source("http://example.com/path", "http://example.com/favicon.png")
+
+        assert result["file"] == "override"
+        assert result["precedence"] == 1
+        assert result["cache_key"] == "example.com"
+
+    @patch("library.html_util._load_yaml_with_cache")
+    def test_get_favicon_cache_source_returns_not_found_for_mismatch(self, mock_load_cache):
+        """Test that get_favicon_cache_source returns not found when URL doesn't match."""
+        from library.html_util import get_favicon_cache_source
+
+        # Function calls loaders in order: discovered, defaults, overrides
+        mock_load_cache.side_effect = [
+            {},  # discovered_cache (called 1st)
+            {},  # defaults_cache (called 2nd)
+            {"example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}},  # overrides_cache (called 3rd)
+        ]
+
+        result = get_favicon_cache_source("http://example.com/path", "http://other.com/favicon.ico")
+
+        assert result["file"] is None
+        assert result["precedence"] is None
 
 
 if __name__ == "__main__":

--- a/tests/test_html_util.py
+++ b/tests/test_html_util.py
@@ -241,7 +241,9 @@ class TestGetFaviconCacheDictFormat:
         inline_data = "data:image/png;base64,abc123"
         # Setup mock to return dict-format entry with inline
         mock_load_cache.side_effect = [
-            {"example.com": {"url": "http://example.com/favicon.png", "inline": inline_data}},  # overrides_cache
+            {
+                "example.com": {"url": "http://example.com/favicon.png", "inline": inline_data}
+            },  # overrides_cache
             {},  # defaults_cache
             {},  # discovered_cache
         ]
@@ -286,7 +288,9 @@ class TestGetFaviconCacheSource:
             {},  # overrides_cache (called 3rd)
         ]
 
-        result = get_favicon_cache_source("http://example.com/path", "http://example.com/favicon.ico")
+        result = get_favicon_cache_source(
+            "http://example.com/path", "http://example.com/favicon.ico"
+        )
 
         assert result["file"] == "discovered"
         assert result["precedence"] == 3
@@ -300,10 +304,14 @@ class TestGetFaviconCacheSource:
         mock_load_cache.side_effect = [
             {},  # discovered_cache (called 1st)
             {},  # defaults_cache (called 2nd)
-            {"example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}},  # overrides_cache (called 3rd)
+            {
+                "example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}
+            },  # overrides_cache (called 3rd)
         ]
 
-        result = get_favicon_cache_source("http://example.com/path", "http://example.com/favicon.png")
+        result = get_favicon_cache_source(
+            "http://example.com/path", "http://example.com/favicon.png"
+        )
 
         assert result["file"] == "override"
         assert result["precedence"] == 1
@@ -318,7 +326,9 @@ class TestGetFaviconCacheSource:
         mock_load_cache.side_effect = [
             {},  # discovered_cache (called 1st)
             {},  # defaults_cache (called 2nd)
-            {"example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}},  # overrides_cache (called 3rd)
+            {
+                "example.com": {"url": "http://example.com/favicon.png", "inline": "data:xxx"}
+            },  # overrides_cache (called 3rd)
         ]
 
         result = get_favicon_cache_source("http://example.com/path", "http://other.com/favicon.ico")

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -385,12 +385,17 @@ class TestEncodeFaviconInline:
         call_args = mock_image.resize.call_args[0]
         assert call_args[0][1] == 20  # height should be 20
 
-    def test_returns_none_for_invalid_url(self):
+    @patch("library.img_util.url_util.get_url")
+    def test_returns_none_for_invalid_url(self, mock_get_url):
         """Test that function returns None for invalid URL."""
+        from library.url_util import SerializedResponseError
+
+        mock_get_url.side_effect = SerializedResponseError("Connection refused")
+
         encode_favicon_inline.cache_clear()
         result = encode_favicon_inline("http://invalid.example.invalid/notfound.png")
-        # Invalid URLs should return None (connection error or non-image)
-        assert result is None or isinstance(result, str)
+
+        assert result is None
 
 
 class TestEncodeFaviconInlineIntegration:

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -14,6 +14,7 @@ from library.img_util import (
     SVG_WIDTH,
     convert_ico,
     convert_svg,
+    encode_favicon_inline,
 )
 
 
@@ -271,6 +272,138 @@ class TestImageConversionEdgeCases:
 
             # Should attempt conversion
             assert mock_image.save.called or result is not None or result is None
+
+
+class TestEncodeFaviconInline:
+    """Tests for encode_favicon_inline function."""
+
+    def test_function_exists(self):
+        """Test that encode_favicon_inline function exists."""
+        assert callable(encode_favicon_inline)
+
+    def test_has_lru_cache(self):
+        """Test that encode_favicon_inline has lru_cache decorator."""
+        assert hasattr(encode_favicon_inline, "cache_info")
+        assert callable(encode_favicon_inline.cache_info)
+
+    def test_cache_can_be_cleared(self):
+        """Test that cache can be cleared."""
+        if hasattr(encode_favicon_inline, "cache_clear"):
+            encode_favicon_inline.cache_clear()
+            info = encode_favicon_inline.cache_info()
+            assert info.hits == 0
+
+    def test_accepts_href_parameter(self):
+        """Test that encode_favicon_inline accepts href parameter."""
+        import inspect
+
+        sig = inspect.signature(encode_favicon_inline)
+        assert "href" in sig.parameters
+
+    def test_accepts_target_height_parameter(self):
+        """Test that encode_favicon_inline accepts target_height parameter."""
+        import inspect
+
+        sig = inspect.signature(encode_favicon_inline)
+        assert "target_height" in sig.parameters
+
+    def test_default_target_height_is_20(self):
+        """Test that default target_height is 20."""
+        import inspect
+
+        sig = inspect.signature(encode_favicon_inline)
+        assert sig.parameters["target_height"].default == 20
+
+    @patch("library.img_util.url_util.get_url")
+    def test_returns_none_on_network_error(self, mock_get_url):
+        """Test that function returns None on network error."""
+        from library.url_util import SerializedResponseError
+
+        mock_get_url.side_effect = SerializedResponseError("Network error")
+
+        encode_favicon_inline.cache_clear()
+        result = encode_favicon_inline("http://example.com/favicon.png")
+
+        assert result is None
+
+    @patch("library.img_util.url_util.get_url")
+    def test_returns_none_for_invalid_response(self, mock_get_url):
+        """Test that function returns None for invalid response."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("Invalid")
+        mock_get_url.return_value = mock_response
+
+        encode_favicon_inline.cache_clear()
+        result = encode_favicon_inline("http://example.com/favicon.png")
+
+        assert result is None
+
+    @patch("library.img_util.Image.open")
+    @patch("library.img_util.url_util.get_url")
+    def test_returns_base64_data_url_on_success(self, mock_get_url, mock_image_open):
+        """Test that function returns base64 data URL on success."""
+        mock_response = MagicMock()
+        mock_response.content = b"fake_image_data"
+        mock_response.raise_for_status.return_value = None
+        mock_get_url.return_value = mock_response
+
+        mock_image = MagicMock()
+        mock_image.width = 32
+        mock_image.height = 32
+        mock_image.resize.return_value = mock_image
+        mock_image.save.return_value = None
+        mock_image_open.return_value = mock_image
+
+        encode_favicon_inline.cache_clear()
+        result = encode_favicon_inline("http://example.com/favicon.png")
+
+        assert result is not None
+        assert result.startswith("data:image/png;base64,")
+
+    @patch("library.img_util.Image.open")
+    @patch("library.img_util.url_util.get_url")
+    def test_respects_target_height_parameter(self, mock_get_url, mock_image_open):
+        """Test that function resizes to target height."""
+        mock_response = MagicMock()
+        mock_response.content = b"fake_image_data"
+        mock_response.raise_for_status.return_value = None
+        mock_get_url.return_value = mock_response
+
+        mock_image = MagicMock()
+        mock_image.width = 100
+        mock_image.height = 50
+        mock_image.resize.return_value = mock_image
+        mock_image.save.return_value = None
+        mock_image_open.return_value = mock_image
+
+        encode_favicon_inline.cache_clear()
+        result = encode_favicon_inline("http://example.com/favicon.png", target_height=20)
+
+        assert result is not None
+        # Verify resize was called with calculated width (100/50 * 20 = 40) and height 20
+        mock_image.resize.assert_called_once()
+        call_args = mock_image.resize.call_args[0]
+        assert call_args[0][1] == 20  # height should be 20
+
+    def test_returns_none_for_invalid_url(self):
+        """Test that function returns None for invalid URL."""
+        encode_favicon_inline.cache_clear()
+        result = encode_favicon_inline("http://invalid.example.invalid/notfound.png")
+        # Invalid URLs should return None (connection error or non-image)
+        assert result is None or isinstance(result, str)
+
+
+class TestEncodeFaviconInlineIntegration:
+    """Integration tests for encode_favicon_inline."""
+
+    def test_function_is_callable(self):
+        """Test that encode_favicon_inline is callable."""
+        assert callable(encode_favicon_inline)
+
+    def test_has_caching(self):
+        """Test that function uses caching."""
+        assert hasattr(encode_favicon_inline, "cache_info")
+        assert hasattr(encode_favicon_inline, "cache_clear")
 
 
 if __name__ == "__main__":

--- a/web-tool.py
+++ b/web-tool.py
@@ -387,7 +387,7 @@ def add_favicon_override():
             # Encode favicon inline (resized to height=20) and store as dict
             inline_data = img_util.encode_favicon_inline(favicon_url, html_util.FAVICON_HEIGHT)
             if inline_data:
-                overrides[cache_key] = {'url': favicon_url, 'inline': inline_data}
+                overrides[cache_key] = {'url': favicon_url, 'inline_image': inline_data}
             else:
                 # Fallback to URL if encoding fails
                 overrides[cache_key] = favicon_url

--- a/web-tool.py
+++ b/web-tool.py
@@ -254,7 +254,7 @@ def get_mirror_favicons():
             metadata.url,
             cache_favicon.href
         )
-        
+
         # Try to get image size, but include even if it fails
         if size := url_util.get_image_size(cache_favicon.href):
             cache_favicon.width = size.width
@@ -265,8 +265,12 @@ def get_mirror_favicons():
             cache_favicon.width = 0
             cache_favicon.height = 0
             cache_favicon.image_type = "invalid"
-        
+
         favicons.insert(0, cache_favicon)
+
+    # Note: inline_image is only set for favicons that were stored with inline data in cache.
+    # We do NOT compute inline on-the-fly here - that would defeat the purpose of
+    # storing inline data in the cache to avoid recomputation.
     
     # Auto-cache the top favicon if none is cached and we have valid favicons
     if not cache_favicon and favicons:
@@ -317,12 +321,13 @@ def get_mirror_favicons():
 @app.route('/add-favicon-override', methods=['POST'])
 def add_favicon_override():
     """Add a favicon override to the user override file.
-    
+
     Accepts JSON with:
     - favicon_url: The URL of the favicon to cache
     - page_url: The URL of the page
     - scope: 'domain' or 'path'
-    
+    - save_inline: If true, store as inline base64 instead of URL
+
     Returns JSON with:
     - success: bool
     - cache_key: The key used (if successful)
@@ -333,21 +338,22 @@ def add_favicon_override():
         favicon_url = data.get('favicon_url')
         page_url = data.get('page_url')
         scope = data.get('scope', 'domain')
-        
+        save_inline = data.get('save_inline', False)
+
         if not favicon_url or not page_url:
             return json.dumps({
                 'success': False,
                 'error': 'Missing favicon_url or page_url'
             }), 400, {'Content-Type': 'application/json'}
-        
+
         # Parse the URL to determine cache key
         parsed = urlparse(page_url)
-        
+
         # Normalize netloc: always remove www. prefix for consistency
         netloc = parsed.netloc
         if netloc.startswith("www."):
             netloc = netloc[4:]
-        
+
         if scope == 'path':
             # Use domain + first path segment
             path_part = parsed.path
@@ -361,7 +367,7 @@ def add_favicon_override():
         else:
             # Use domain only
             cache_key = netloc
-        
+
         # Read current file to preserve header comments
         header_lines = []
         if html_util.FAVICON_OVERRIDES.exists():
@@ -372,13 +378,22 @@ def add_favicon_override():
                     else:
                         # Stop when we hit the first non-comment, non-empty line
                         break
-        
+
         # Load current overrides
         overrides = html_util._load_yaml_with_cache(html_util.FAVICON_OVERRIDES)
-        
+
         # Add the new override
-        overrides[cache_key] = favicon_url
-        
+        if save_inline:
+            # Encode favicon inline (resized to height=20) and store as dict
+            inline_data = img_util.encode_favicon_inline(favicon_url, html_util.FAVICON_HEIGHT)
+            if inline_data:
+                overrides[cache_key] = {'url': favicon_url, 'inline': inline_data}
+            else:
+                # Fallback to URL if encoding fails
+                overrides[cache_key] = favicon_url
+        else:
+            overrides[cache_key] = favicon_url
+
         # Write back to file with preserved header
         with open(html_util.FAVICON_OVERRIDES, "w") as f:
             # Write header comments first
@@ -386,17 +401,17 @@ def add_favicon_override():
                 f.write(line)
             # Write YAML data in sorted order
             yaml.dump(overrides, f, sort_keys=True)
-        
+
         # Invalidate in-memory cache
         file_path_str = str(html_util.FAVICON_OVERRIDES)
         if file_path_str in html_util._favicon_yaml_cache:
             del html_util._favicon_yaml_cache[file_path_str]
-        
+
         return json.dumps({
             'success': True,
             'cache_key': cache_key
         }), 200, {'Content-Type': 'application/json'}
-        
+
     except Exception as e:
         return json.dumps({
             'success': False,
@@ -503,12 +518,17 @@ def get_mirror_links():
             seen_values.add(title_value)
 
     if metadata.favicons:
+        # Get inline base64 favicon only if stored in cache
+        favicon_inline = None
+        if metadata.favicons and metadata.favicons[0].inline_image:
+            favicon_inline = metadata.favicons[0].inline_image
+
         if metadata.fragment_title:
             links.append({
                 "header": "Favicon",
                 "html": (
                     f'<img src="{metadata.favicon_url}" '
-                    f'width="{html_util.FAVICON_WIDTH}" /> '
+                    f'height="{html_util.FAVICON_HEIGHT}" /> '
                     f'<a target="_blank" href="{metadata.url}">'
                     f'{util.html_text(util.ascii_text(metadata.fragment_title))}</a>'
                 ),
@@ -518,7 +538,7 @@ def get_mirror_links():
             "header": "Favicon - Clean",
             "html": (
                 f'<img src="{metadata.favicon_url}" '
-                f'width="{html_util.FAVICON_WIDTH}" /> '
+                f'height="{html_util.FAVICON_HEIGHT}" /> '
                 f'<a target="_blank" href="{metadata.url_clean}">'
                 f'{util.html_text(util.ascii_text(metadata.title))}</a>'
             ),
@@ -555,6 +575,7 @@ def get_mirror_links():
         'url_variants': url_variants,
         'links': links,
         'favicon': metadata.favicon_url,
+        'favicon_inline': favicon_inline,
     })
 
     resp = make_response(rendered_html)

--- a/web-tool.py
+++ b/web-tool.py
@@ -517,10 +517,10 @@ def get_mirror_links():
             seen_labels.add(label)
             seen_values.add(title_value)
 
+    # Get inline base64 favicon (only if stored in cache)
+    favicon_inline = None
     if metadata.favicons:
-        # Get inline base64 favicon only if stored in cache
-        favicon_inline = None
-        if metadata.favicons and metadata.favicons[0].inline_image:
+        if metadata.favicons[0].inline_image:
             favicon_inline = metadata.favicons[0].inline_image
 
         if metadata.fragment_title:


### PR DESCRIPTION
## Summary
- Change favicon display from `width=20` to `height=20` with aspect ratio preserved
- Add `encode_favicon_inline()` function that resizes to 20px height and base64-encodes
- Support storing inline base64 data in three-tier favicon cache
- Add inline option on mirror-links page (only shown when cached as inline)
- Add INLINE badge on mirror-favicons page for cached inline favicons
- Add "Save as inline" checkbox in Add Override form
- Update favicon section UI to match Title/URL section patterns with radio buttons

## Test plan
- [x] 211 tests passing
- [x] Manual testing of inline save on mirror-favicons
- [x] Manual testing of inline display on mirror-links

🤖 Generated with [Claude Code](https://claude.ai/code)