### PR TITLE
Fix fragment duplicate graying in mirror-links page

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -10,8 +10,9 @@ This project uses **pytest** as the testing framework with tests organized in a 
 web-tool/
 ├── tests/
 │   ├── __init__.py
+│   ├── test_fragment_variants.py   # Tests for fragment variant duplicate detection
 │   ├── test_title_variants.py      # Tests for title variant generation
-│   └── test_title_strings.py       # Test data for title variants
+│   └── test_title_strings.py      # Test data for title variants
 ├── pytest.ini                      # Pytest configuration
 ├── pyproject.toml                  # Project configuration with test dependencies
 └── [old test files - deprecated]
@@ -108,6 +109,15 @@ Edge case testing:
 - Combining diacriticals
 - Very long strings
 - Special characters and newlines
+
+#### `TestFragmentVariants` (8 tests)
+Tests for fragment variant generation in mirror-links endpoint:
+- None option is never marked duplicate
+- Fragment Text is marked duplicate when equal to Fragment (fallback case)
+- Fragment Text is not duplicate when different from Fragment
+- All three options present with correct values
+- Empty fragment/text case handled correctly
+- Pydantic-style URLs (fragment_text equals fragment) detected
 
 ## Test Data
 

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -35,26 +35,20 @@
         </div>
     </div>
     
-    {% if fragment %}
+    {% if fragment_variants %}
     <div class="metadata-panel">
         <h2>Fragment</h2>
         <div class="url-list">
-            <div class="url-item">
-                <input type="radio" name="fragment_variant" value="none" data-text="" checked>
-                <span style="min-width: 100px;"><strong>None</strong></span>
-            </div>
-            <div class="url-item">
-                <input type="radio" name="fragment_variant" value="fragment" data-text="{{ fragment|e }}">
-                <button class="copy-btn" data-html="{{ fragment|e }}">Copy</button>
-                <span style="min-width: 100px;"><strong>Fragment</strong></span>
-                <span>{{ fragment|e }}</span>
-            </div>
-            <div class="url-item">
-                <input type="radio" name="fragment_variant" value="fragment_text" data-text="{{ fragment_text|e }}">
-                <button class="copy-btn" data-html="{{ fragment_text|e }}">Copy</button>
-                <span style="min-width: 100px;"><strong>Fragment Text</strong></span>
-                <span>{{ fragment_text|e }}</span>
-            </div>
+            {% for variant in fragment_variants %}
+                <div class="url-item"{% if variant.is_duplicate %} style="opacity: 0.6; background-color: #f5f5f5;"{% endif %}>
+                    <input type="radio" name="fragment_variant" value="fragment{{ loop.index0 }}" data-text="{{ variant.value|e }}" {% if loop.first %}checked{% endif %}>
+                    {% if variant.value %}
+                    <button class="copy-btn" data-html="{{ variant.value|e }}">Copy</button>
+                    {% endif %}
+                    <span style="min-width: 100px;"><strong>{{ variant.label }}</strong></span>
+                    <span>{{ variant.value|e }}</span>
+                </div>
+            {% endfor %}
         </div>
     </div>
     {% endif %}

--- a/tests/test_fragment_variants.py
+++ b/tests/test_fragment_variants.py
@@ -1,0 +1,111 @@
+"""
+Tests for fragment variant generation in mirror-links endpoint.
+
+Tests the fragment_variants list creation with duplicate detection,
+verifying that is_duplicate is set correctly when fragment_text
+equals fragment (fallback case).
+"""
+
+import pytest
+
+from library.util import PageMetadata
+
+
+class TestFragmentVariants:
+    """Tests for fragment variant generation."""
+
+    def _make_fragment_variants(self, fragment, fragment_text):
+        """
+        Helper to build fragment_variants like the mirror-links endpoint does.
+        """
+        fragment_variants_data = [
+            ('', 'None'),
+            (fragment, 'Fragment'),
+            (fragment_text, 'Fragment Text'),
+        ]
+
+        seen_values = set()
+        result = []
+        for fragment_value, label in fragment_variants_data:
+            value = fragment_value if label != 'None' else ''
+            is_duplicate = value in seen_values and label != 'None'
+            result.append({
+                'value': value,
+                'label': label,
+                'is_duplicate': is_duplicate
+            })
+            seen_values.add(value)
+        return result
+
+    def test_none_not_marked_duplicate(self):
+        """None option should never be marked as duplicate."""
+        variants = self._make_fragment_variants('section1', 'Section One')
+        none_variant = next(v for v in variants if v['label'] == 'None')
+        assert none_variant['is_duplicate'] is False
+
+    def test_fragment_not_duplicate_when_unique(self):
+        """Fragment should not be duplicate when different from None."""
+        variants = self._make_fragment_variants('section1', 'Section One')
+        fragment_variant = next(v for v in variants if v['label'] == 'Fragment')
+        assert fragment_variant['is_duplicate'] is False
+
+    def test_fragment_text_duplicate_when_equal_to_fragment(self):
+        """Fragment Text should be marked duplicate when equal to Fragment."""
+        variants = self._make_fragment_variants('section1', 'section1')
+        fragment_text_variant = next(v for v in variants if v['label'] == 'Fragment Text')
+        assert fragment_text_variant['is_duplicate'] is True
+
+    def test_fragment_text_not_duplicate_when_different(self):
+        """Fragment Text should not be duplicate when different from Fragment."""
+        variants = self._make_fragment_variants('section1', 'Section One')
+        fragment_text_variant = next(v for v in variants if v['label'] == 'Fragment Text')
+        assert fragment_text_variant['is_duplicate'] is False
+
+    def test_all_three_options_present(self):
+        """All three options (None, Fragment, Fragment Text) should be present."""
+        variants = self._make_fragment_variants('section1', 'Section One')
+        labels = {v['label'] for v in variants}
+        assert labels == {'None', 'Fragment', 'Fragment Text'}
+
+    def test_values_correct(self):
+        """Values should be correctly assigned to each option."""
+        variants = self._make_fragment_variants('my-fragment', 'My Fragment')
+        none = next(v for v in variants if v['label'] == 'None')
+        fragment = next(v for v in variants if v['label'] == 'Fragment')
+        fragment_text = next(v for v in variants if v['label'] == 'Fragment Text')
+
+        assert none['value'] == ''
+        assert fragment['value'] == 'my-fragment'
+        assert fragment_text['value'] == 'My Fragment'
+
+    def test_empty_fragment_and_text(self):
+        """
+        Handles case where both fragment and fragment_text are empty.
+        All three options have empty values, so Fragment and Fragment Text
+        are duplicates of None.
+        """
+        variants = self._make_fragment_variants('', '')
+        none = next(v for v in variants if v['label'] == 'None')
+        fragment = next(v for v in variants if v['label'] == 'Fragment')
+        fragment_text = next(v for v in variants if v['label'] == 'Fragment Text')
+
+        # None is not marked duplicate (by design - it's the reference)
+        assert none['is_duplicate'] is False
+        # Fragment is duplicate of None (both empty = no fragment)
+        assert fragment['is_duplicate'] is True
+        # Fragment Text is also duplicate of None
+        assert fragment_text['is_duplicate'] is True
+
+    def test_pydantic_style_fragment_falls_back_to_self(self):
+        """
+        Simulates pydantic URL case where fragment_text equals fragment
+        because resolver couldn't find descriptive text.
+        """
+        fragment = 'pydantic.json_schema.GenerateJsonSchema.ValidationsMapping'
+        variants = self._make_fragment_variants(fragment, fragment)
+        fragment_variant = next(v for v in variants if v['label'] == 'Fragment')
+        fragment_text_variant = next(v for v in variants if v['label'] == 'Fragment Text')
+
+        assert fragment_variant['value'] == fragment
+        assert fragment_text_variant['value'] == fragment
+        assert fragment_text_variant['is_duplicate'] is True

--- a/web-tool.py
+++ b/web-tool.py
@@ -462,6 +462,26 @@ def get_mirror_links():
     """
     metadata = util.get_page_metadata()
 
+    # build fragment variants with duplicate detection
+    fragment_variants = []
+    fragment_variants_data = [
+        ('', 'None'),
+        (metadata.parsed_url.fragment if metadata.parsed_url else '', 'Fragment'),
+        (metadata.fragment_text, 'Fragment Text'),
+    ]
+
+    seen_values = set()
+    for fragment_value, label in fragment_variants_data:
+        # For 'None', use empty string as the value
+        value = fragment_value if label != 'None' else ''
+        is_duplicate = value in seen_values and label != 'None'
+        fragment_variants.append({
+            'value': value,
+            'label': label,
+            'is_duplicate': is_duplicate
+        })
+        seen_values.add(value)
+
     # build urls with labels - always start with Original
     url_variants = []
     url_variants_data = [
@@ -471,7 +491,7 @@ def get_mirror_links():
         (metadata.url_root, 'Root'),
         (metadata.url_host, 'Host'),
     ]
-    
+
     seen_labels = set()
     seen_values = set()
     for url, label in url_variants_data:
@@ -567,6 +587,7 @@ def get_mirror_links():
         'title_variants': title_variant_list,
         'fragment': metadata.parsed_url.fragment if metadata.parsed_url else '',
         'fragment_text': metadata.fragment_text,
+        'fragment_variants': fragment_variants,
         'content_type': metadata.content_type,
         'clipboard_error': metadata.clipboard_error,
         'user_agent': metadata.mirror_data.userAgent if metadata.mirror_data else '',


### PR DESCRIPTION
## Summary
- Add duplicate graying to fragment section in mirror-links page
- Fragment Text option is now greyed out when it equals Fragment (fallback case where resolver couldn't find descriptive text)
- Matches existing behavior of title and URL sections

## Changes
- **web-tool.py**: Add `fragment_variants` list with `is_duplicate` detection
- **templates/mirror-links.html**: Refactor fragment section to use variant loop with duplicate styling
- **tests/test_fragment_variants.py**: Add 8 tests for fragment variant duplicate detection

## Test Plan
- [x] All 219 tests passing
- [x] Manual testing with pydantic URL confirms Fragment Text is greyed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)