### PR TITLE
Validate favicon URLs and fix fragment/encoding issues

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -226,6 +226,16 @@ dev = [
 
 7. **Keep tests independent**: Each test should be able to run in isolation
 
+8. **Mock clipboard access**: Tests that instantiate `PageMetadata` should patch `pyperclip.paste` to avoid environment-dependent failures:
+   ```python
+   from unittest.mock import patch
+
+   @patch("pyperclip.paste")
+   def test_url_decoding(self, mock_paste):
+       mock_paste.return_value = ""
+       # ... test code
+   ```
+
 ## Common Issues
 
 ### Import Errors

--- a/TESTING.md
+++ b/TESTING.md
@@ -237,6 +237,49 @@ uv pip install -e ".[dev]"
 uv run pytest tests/ --cov=library --cov-report=xml
 ```
 
+## Manual/Integration Testing
+
+Some edge cases require end-to-end testing via the browser bookmarklet since unit tests cannot fully capture the clipboard/bookmarklet flow.
+
+### Edge-Case URLs for Manual Testing
+
+Test these URLs by bookmarking them and clicking the bookmarklet on each page:
+
+| URL | Description | Expected Behavior |
+|-----|-------------|-------------------|
+| `https://example.com` | Simple URL, no fragment | No fragment section displayed |
+| `https://example.com/page#section1` | URL with simple fragment | Fragment section shows "section1" |
+| `https://pydantic.com.cn/en/api/json_schema/#pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method` | Fragment containing dots | Fragment section shows correct fragment text, link displays correctly |
+| `https://example.com/page#has-dots.and.dots.and.dots` | Fragment with multiple dot sequences | Fragment preserved correctly |
+| `https://example.com/favicon.ico` | Favicon is ICO, not PNG | ICO converted to PNG inline |
+| `https://example.com/no-such-favicon.png` | Favicon URL returns 404 | Favicon section hidden (URL not valid image) |
+
+### Manual Test Checklist
+
+1. **URL with no fragment** (`https://example.com`):
+   - [ ] Fragment section does not appear
+   - [ ] URL section shows "Original", "Clean", "Root", "Host"
+   - [ ] Link displays correctly with title
+
+2. **URL with fragment containing dots** (`https://pydantic.com.cn/...#pydantic.json_schema...`):
+   - [ ] Fragment section appears with correct fragment text
+   - [ ] All radio buttons work and update the Link preview
+   - [ ] URL "With Fragment" variant includes full fragment
+   - [ ] Copy buttons work
+
+3. **Favicon validation**:
+   - [ ] URLs with broken favicons (404) show no favicon section
+   - [ ] URLs with valid favicons show favicon section
+   - [ ] Inline vs URL options work
+
+### Bookmarklet Testing
+
+To test the bookmarklet:
+1. Run the web-tool server: `make run`
+2. Navigate to a test URL in your browser
+3. Click the "Mirror Links" bookmarklet
+4. Verify the mirror-links page displays correctly
+
 ## Resources
 
 - [Pytest Documentation](https://docs.pytest.org/)

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,9 +10,18 @@ This project uses **pytest** as the testing framework with tests organized in a 
 web-tool/
 ├── tests/
 │   ├── __init__.py
+│   ├── test_docker_util.py         # Tests for Docker detection
 │   ├── test_fragment_variants.py   # Tests for fragment variant duplicate detection
-│   ├── test_title_variants.py      # Tests for title variant generation
-│   └── test_title_strings.py      # Test data for title variants
+│   ├── test_favicon_validation.py # Tests for favicon validation (get_valid_favicon_links)
+│   ├── test_html_util.py          # Tests for HTML parsing and favicon discovery
+│   ├── test_img_util.py           # Tests for image conversion
+│   ├── test_js_escaping.py        # Tests for JavaScript string escaping in templates
+│   ├── test_text_util.py          # Tests for text utilities
+│   ├── test_title_strings.py      # Test data for title variants
+│   ├── test_title_variants.py     # Tests for title variant generation
+│   ├── test_unicode_util.py       # Tests for Unicode utilities
+│   ├── test_url_decoding.py       # Tests for URL encoding/decoding
+│   └── test_url_util.py           # Tests for URL utilities
 ├── pytest.ini                      # Pytest configuration
 ├── pyproject.toml                  # Project configuration with test dependencies
 └── [old test files - deprecated]
@@ -118,6 +127,38 @@ Tests for fragment variant generation in mirror-links endpoint:
 - All three options present with correct values
 - Empty fragment/text case handled correctly
 - Pydantic-style URLs (fragment_text equals fragment) detected
+
+#### `TestGetValidFaviconLinks` (6 tests)
+Tests for `get_valid_favicon_links()` function in `html_util.py`:
+- Returns only validated links (filters out broken favicon URLs)
+- Returns empty list when no valid favicons found
+- Passes `max_count` and `favicon_height` parameters correctly
+- Composes `get_favicon_links`, `sort_favicon_links`, and `validate_top_candidates`
+
+#### `TestValidateTopCandidates` (3 tests)
+Tests for `validate_top_candidates()` function:
+- Returns empty list for empty input
+- Returns single valid link
+- Returns multiple valid links up to max_count
+
+#### `TestPageMetadataUrlDecoding` (6 tests)
+Tests for URL decoding in `PageMetadata`:
+- URL with fragment containing dots is properly decoded
+- URL without fragment is decoded
+- URL with query string is decoded
+- URL with `%23` (encoded `#`) is decoded to `#`
+- Already-decoded URLs pass through unchanged
+- Empty URL handled gracefully
+
+#### `TestMirrorLinksJsEscaping` (7 tests)
+Tests for JavaScript string escaping in `mirror-links.html` template:
+- Fragment text with newlines properly escaped (using `|tojson`)
+- Fragment text with special characters (quotes) escaped
+- Title with Unicode characters escaped
+- URL with fragment containing dots rendered correctly
+- Empty fragment renders empty string for `fragmentText`
+- Null favicon renders as `null` in JavaScript
+- Favicon URL renders as JavaScript string
 
 ## Test Data
 

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -548,6 +548,33 @@ def validate_top_candidates(links: list[RelLink], max_count: int = 1) -> list[Re
     return validated
 
 
+def get_valid_favicon_links(
+    page_url: str,
+    soup: BeautifulSoup,
+    max_count: int = 1,
+    favicon_height: int = FAVICON_HEIGHT,
+) -> list[RelLink]:
+    """Get valid favicon links for a page.
+
+    Discovers favicon candidates and validates them, returning only those
+    that resolve to valid images. This is the primary interface for getting
+    favicons that are guaranteed to be valid.
+
+    Args:
+        page_url: The URL of the page
+        soup: BeautifulSoup parsed HTML (or None)
+        max_count: Maximum number of valid favicons to return
+        favicon_height: Target height in pixels for optimal size sorting
+
+    Returns:
+        List of validated RelLink objects that resolved to valid images.
+        Returns empty list if no valid favicons found.
+    """
+    links = get_favicon_links(page_url, soup)
+    sorted_links = sort_favicon_links(links, favicon_height)
+    return validate_top_candidates(sorted_links, max_count)
+
+
 def get_common_favicon_links(page_url):
     """Get the common favicon links for the page URL."""
 

--- a/library/html_util.py
+++ b/library/html_util.py
@@ -8,6 +8,7 @@ import pyperclip
 import yaml
 from bs4 import BeautifulSoup
 from flask import request
+from typing import Optional
 from lxml import html as lxml_html
 
 from library import docker_util, img_util, url_util
@@ -402,7 +403,7 @@ def add_favicon_to_cache(cache_key, favicon_link):
         del _favicon_yaml_cache[file_path_str]
 
 
-def get_favicon_links(page_url: str, soup: BeautifulSoup, include=None) -> list[RelLink]:
+def get_favicon_links(page_url: str, soup: Optional[BeautifulSoup], include=None) -> list[RelLink]:
     """Get the favicon links for the page URL.
 
     Discovers native favicon formats first. Only creates ICO/SVG→PNG conversions
@@ -550,7 +551,7 @@ def validate_top_candidates(links: list[RelLink], max_count: int = 1) -> list[Re
 
 def get_valid_favicon_links(
     page_url: str,
-    soup: BeautifulSoup,
+    soup: Optional[BeautifulSoup],
     max_count: int = 1,
     favicon_height: int = FAVICON_HEIGHT,
 ) -> list[RelLink]:

--- a/library/util.py
+++ b/library/util.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from pprint import pprint
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, unquote
 
 import fitz
 import jsmin
@@ -185,6 +185,8 @@ class PageMetadata:
             return
 
         self.url = self.request.args.get("url", "")
+        # URL-decode the URL since bookmarklet sends it encoded
+        self.url = unquote(self.url)
         self.parsed_url = urlparse(self.url)
         self.title = self.request.args.get("title", "")
         self.headers = dict(self.request.headers)
@@ -504,7 +506,7 @@ class PageMetadata:
         return ""
 
     def resolve_favicons(self):
-        self.favicons = html_util.get_favicon_links(
+        self.favicons = html_util.get_valid_favicon_links(
             self.url,
             self.soup,
         )

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -133,10 +133,10 @@
     <script>
         // Store default values
         const defaultValues = {
-            title: '{{ title_variants[0].value|e }}',
-            fragmentText: {% if fragment %}'{{ fragment_text|e }}'{% else %}''{% endif %},
-            url: '{{ url_variants[0].url|e }}',
-            favicon: {% if favicon %}'{{ favicon|e }}'{% else %}null{% endif %},
+            title: {{ title_variants[0].value|tojson }},
+            fragmentText: {% if fragment %}{{ fragment_text|tojson }}{% else %}''{% endif %},
+            url: {{ url_variants[0].url|tojson }},
+            favicon: {% if favicon %}{{ favicon|tojson }}{% else %}null{% endif %},
             faviconInline: {% if favicon_inline %}{{ favicon_inline|tojson }}{% else %}null{% endif %}
         };
 

--- a/templates/mirror.js
+++ b/templates/mirror.js
@@ -15,7 +15,7 @@ var c = {
 c.htmlSize = c.html.length;
 
 p.append('title', c.title);
-p.append('url', c.url);
+p.append('url', encodeURIComponent(c.url));
 p.append('format', '{{ format }}');
 
 // Function to handle clipboard error and make HEAD request

--- a/tests/test_favicon_validation.py
+++ b/tests/test_favicon_validation.py
@@ -1,0 +1,145 @@
+"""
+Tests for favicon validation functionality.
+
+Tests the get_valid_favicon_links() function and related validation logic.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from library.html_util import (
+    RelLink,
+    get_favicon_links,
+    get_valid_favicon_links,
+    sort_favicon_links,
+    validate_top_candidates,
+)
+
+
+class TestGetValidFaviconLinks:
+    """Tests for get_valid_favicon_links function."""
+
+    @patch("library.html_util.get_favicon_links")
+    @patch("library.html_util.validate_top_candidates")
+    @patch("library.html_util.sort_favicon_links")
+    def test_returns_validated_links_only(self, mock_sort, mock_validate, mock_get_links):
+        """Test that only validated links are returned."""
+        mock_links = [RelLink(href="http://example.com/favicon.png")]
+        mock_get_links.return_value = mock_links
+        mock_sort.return_value = mock_links
+        mock_validate.return_value = mock_links
+
+        result = get_valid_favicon_links("http://example.com", None)
+
+        assert result == mock_links
+        mock_get_links.assert_called_once_with("http://example.com", None)
+        mock_sort.assert_called_once_with(mock_links, 20)
+        mock_validate.assert_called_once_with(mock_links, 1)
+
+    @patch("library.html_util.get_favicon_links")
+    @patch("library.html_util.validate_top_candidates")
+    @patch("library.html_util.sort_favicon_links")
+    def test_returns_empty_when_no_valid_favicons(self, mock_sort, mock_validate, mock_get_links):
+        """Test that empty list is returned when no valid favicons."""
+        mock_links = [RelLink(href="http://example.com/bad.png")]
+        mock_get_links.return_value = mock_links
+        mock_sort.return_value = mock_links
+        mock_validate.return_value = []  # None pass validation
+
+        result = get_valid_favicon_links("http://example.com", None)
+
+        assert result == []
+
+    @patch("library.html_util.get_favicon_links")
+    @patch("library.html_util.validate_top_candidates")
+    @patch("library.html_util.sort_favicon_links")
+    def test_max_count_passed_to_validate(self, mock_sort, mock_validate, mock_get_links):
+        """Test that max_count parameter is passed to validate_top_candidates."""
+        mock_links = [RelLink(href="http://example.com/favicon.png")]
+        mock_get_links.return_value = mock_links
+        mock_sort.return_value = mock_links
+        mock_validate.return_value = mock_links
+
+        get_valid_favicon_links("http://example.com", None, max_count=5)
+
+        mock_validate.assert_called_once_with(mock_links, 5)
+
+    @patch("library.html_util.get_favicon_links")
+    @patch("library.html_util.validate_top_candidates")
+    @patch("library.html_util.sort_favicon_links")
+    def test_custom_favicon_height_passed_to_sort(self, mock_sort, mock_validate, mock_get_links):
+        """Test that custom favicon_height is passed to sort_favicon_links."""
+        mock_links = [RelLink(href="http://example.com/favicon.png")]
+        mock_get_links.return_value = mock_links
+        mock_sort.return_value = mock_links
+        mock_validate.return_value = mock_links
+
+        get_valid_favicon_links("http://example.com", None, favicon_height=32)
+
+        mock_sort.assert_called_once_with(mock_links, 32)
+
+    def test_function_signature(self):
+        """Test that function exists and has correct signature."""
+        import inspect
+
+        sig = inspect.signature(get_valid_favicon_links)
+        params = list(sig.parameters.keys())
+
+        assert "page_url" in params
+        assert "soup" in params
+        assert "max_count" in params
+        assert "favicon_height" in params
+
+    @patch("library.html_util.get_favicon_links")
+    @patch("library.html_util.validate_top_candidates")
+    @patch("library.html_util.sort_favicon_links")
+    def test_default_parameters(self, mock_sort, mock_validate, mock_get_links):
+        """Test that default parameters work correctly."""
+        mock_links = [RelLink(href="http://example.com/favicon.png")]
+        mock_get_links.return_value = mock_links
+        mock_sort.return_value = mock_links
+        mock_validate.return_value = mock_links
+
+        get_valid_favicon_links("http://example.com", None)
+
+        # Check defaults: max_count=1, favicon_height=20
+        mock_sort.assert_called_once_with(mock_links, 20)
+        mock_validate.assert_called_once_with(mock_links, 1)
+
+
+class TestValidateTopCandidates:
+    """Tests for validate_top_candidates function behavior."""
+
+    def test_returns_empty_for_empty_input(self):
+        """Test that empty list returns empty."""
+        result = validate_top_candidates([])
+        assert result == []
+
+    def test_returns_single_valid_link(self):
+        """Test single valid link is returned."""
+        link = RelLink(href="http://example.com/favicon.png")
+        link.resolved_href = "http://example.com/favicon.png"
+        link.image_type = "image/png"
+        link._validated = True  # Mark as already validated
+
+        result = validate_top_candidates([link])
+        assert len(result) == 1
+        assert result[0] == link
+
+    def test_returns_multiple_valid_links_up_to_max_count(self):
+        """Test multiple valid links up to max_count."""
+        links = []
+        for i in range(3):
+            link = RelLink(href=f"http://example.com/favicon{i}.png")
+            link.resolved_href = link.href
+            link.image_type = "image/png"
+            link._validated = True  # Mark as already validated
+            links.append(link)
+
+        result = validate_top_candidates(links, max_count=2)
+        assert len(result) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_js_escaping.py
+++ b/tests/test_js_escaping.py
@@ -1,0 +1,154 @@
+"""
+Tests for JavaScript string escaping in templates.
+
+Tests that the tojson filter is used correctly for JavaScript strings
+in mirror-links.html, ensuring special characters don't break JS parsing.
+"""
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+
+class TestMirrorLinksJsEscaping:
+    """Tests for JavaScript string escaping in mirror-links template."""
+
+    @pytest.fixture
+    def template_env(self):
+        """Create Jinja2 environment for testing templates."""
+        template_dir = Path(__file__).parent.parent / "templates"
+        env = Environment(loader=FileSystemLoader(template_dir))
+        return env
+
+    def test_fragment_text_with_newline_escaped(self, template_env):
+        """Test that fragment text with newline is properly escaped for JS."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="section",
+            fragment_text="build_schema_type_to_method\n¶",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # The rendered template should contain valid JavaScript
+        # The newline in fragmentText should be escaped as \n
+        assert "fragmentText:" in rendered
+        # Should use tojson which produces valid JS (no bare newlines in string literals)
+        assert "\\n" in rendered or "\\\\n" in rendered or "fragmentText: ''" in rendered
+
+    def test_fragment_text_with_special_chars_escaped(self, template_env):
+        """Test that fragment text with special chars is properly escaped."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="section",
+            fragment_text='test"quote',
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # Should not have bare quotes that would break JS string
+        # tojson should escape the quote as \"
+        assert 'test\\"quote' in rendered or "fragmentText: ''" in rendered
+
+    def test_title_with_unicode_escaped(self, template_env):
+        """Test that title with Unicode characters is properly escaped."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="JSON Schema - Pydantic documentation (en)",
+            title_variants=[{"value": "JSON Schema - Pydantic documentation (en)", "label": "Original"}],
+            fragment="",
+            fragment_text="",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # Should contain the title in JavaScript defaultValues
+        assert "JSON Schema - Pydantic documentation (en)" in rendered
+
+    def test_url_with_fragment_containing_dots(self, template_env):
+        """Test that URL with fragment containing dots is properly escaped."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method",
+            fragment_text="build_schema_type_to_method",
+            url_variants=[
+                {
+                    "url": "https://pydantic.com.cn/en/api/json_schema/#pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method",
+                    "label": "Original",
+                }
+            ],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # URL should be in the template
+        assert "pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method" in rendered
+
+    def test_no_fragment_renders_empty_fragment_text(self, template_env):
+        """Test that empty fragment renders empty string for fragmentText."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="",
+            fragment_text="",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # Should have fragmentText: '' (empty string)
+        assert "fragmentText: ''" in rendered
+
+    def test_null_favicon_renders_null(self, template_env):
+        """Test that null favicon renders as null in JavaScript."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="",
+            fragment_text="",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon=None,
+            favicon_inline=None,
+        )
+
+        # Should have favicon: null
+        assert "favicon: null" in rendered
+
+    def test_favicon_url_renders_correctly(self, template_env):
+        """Test that favicon URL renders as JavaScript string."""
+        template = template_env.get_template("mirror-links.html")
+
+        rendered = template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="",
+            fragment_text="",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon="https://example.com/favicon.png",
+            favicon_inline=None,
+        )
+
+        # Should have favicon as JS string (with quotes)
+        assert "favicon:" in rendered
+        assert "null" not in rendered.split("favicon:")[1].split("\n")[0]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_url_decoding.py
+++ b/tests/test_url_decoding.py
@@ -1,0 +1,101 @@
+"""
+Tests for URL encoding/decoding in PageMetadata.
+
+Tests that URLs from the bookmarklet (which are URL-encoded) are properly
+decoded before parsing to handle fragments containing special characters.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from library.util import PageMetadata
+
+
+class TestPageMetadataUrlDecoding:
+    """Tests for URL decoding in PageMetadata."""
+
+    def _make_mock_request(self, url):
+        """Create a mock Flask request with the given URL."""
+        mock_request = MagicMock()
+        mock_request.args.get.side_effect = lambda key, default=None: {
+            "url": url,
+            "title": "Test Title",
+            "format": "html",
+        }.get(key, default)
+        mock_request.headers = {}
+        return mock_request
+
+    def test_url_with_fragment_containing_dots_is_decoded(self):
+        """Test that URL with fragment containing dots is properly decoded."""
+        # This is the URL-encoded form that comes from the bookmarklet
+        encoded_url = (
+            "https%3A%2F%2Fpydantic.com.cn%2Fen%2Fapi%2Fjson_schema%2F"
+            "%23pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method"
+        )
+        expected_url = (
+            "https://pydantic.com.cn/en/api/json_schema/"
+            "#pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method"
+        )
+
+        mock_request = self._make_mock_request(encoded_url)
+        metadata = PageMetadata(request=mock_request)
+
+        # URL should be decoded
+        assert metadata.url == expected_url
+        # Fragment should be extracted correctly
+        assert metadata.parsed_url.fragment == "pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method"
+
+    def test_url_without_fragment_is_decoded(self):
+        """Test that URL without fragment is properly decoded."""
+        encoded_url = "https%3A%2F%2Fexample.com%2Fpath%2Fpage"
+        expected_url = "https://example.com/path/page"
+
+        mock_request = self._make_mock_request(encoded_url)
+        metadata = PageMetadata(request=mock_request)
+
+        assert metadata.url == expected_url
+        assert metadata.parsed_url.fragment == ""
+
+    def test_url_with_query_string_is_decoded(self):
+        """Test that URL with query string is properly decoded."""
+        encoded_url = "https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtest%2Bvalue"
+        expected_url = "https://example.com/search?q=test+value"
+
+        mock_request = self._make_mock_request(encoded_url)
+        metadata = PageMetadata(request=mock_request)
+
+        assert metadata.url == expected_url
+
+    def test_url_with_percent_in_fragment_is_decoded(self):
+        """Test that URL with %23 in fragment (encoded #) is decoded to #."""
+        # %23 is the URL-encoded form of #
+        encoded_url = "https%3A%2F%2Fexample.com%2Fpage%23section%2Fsub"
+        expected_url = "https://example.com/page#section/sub"
+
+        mock_request = self._make_mock_request(encoded_url)
+        metadata = PageMetadata(request=mock_request)
+
+        assert metadata.url == expected_url
+        assert metadata.parsed_url.fragment == "section/sub"
+
+    def test_url_already_decoded_is_unchanged(self):
+        """Test that already-decoded URL passes through unchanged."""
+        url = "https://example.com/path#fragment"
+
+        mock_request = self._make_mock_request(url)
+        metadata = PageMetadata(request=mock_request)
+
+        assert metadata.url == url
+        assert metadata.parsed_url.fragment == "fragment"
+
+    def test_empty_url_handled(self):
+        """Test that empty URL is handled gracefully."""
+        mock_request = self._make_mock_request("")
+        metadata = PageMetadata(request=mock_request)
+
+        assert metadata.url == ""
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_url_decoding.py
+++ b/tests/test_url_decoding.py
@@ -5,7 +5,7 @@ Tests that URLs from the bookmarklet (which are URL-encoded) are properly
 decoded before parsing to handle fragments containing special characters.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -26,8 +26,10 @@ class TestPageMetadataUrlDecoding:
         mock_request.headers = {}
         return mock_request
 
-    def test_url_with_fragment_containing_dots_is_decoded(self):
+    @patch("pyperclip.paste")
+    def test_url_with_fragment_containing_dots_is_decoded(self, mock_paste):
         """Test that URL with fragment containing dots is properly decoded."""
+        mock_paste.return_value = ""
         # This is the URL-encoded form that comes from the bookmarklet
         encoded_url = (
             "https%3A%2F%2Fpydantic.com.cn%2Fen%2Fapi%2Fjson_schema%2F"
@@ -46,8 +48,10 @@ class TestPageMetadataUrlDecoding:
         # Fragment should be extracted correctly
         assert metadata.parsed_url.fragment == "pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method"
 
-    def test_url_without_fragment_is_decoded(self):
+    @patch("pyperclip.paste")
+    def test_url_without_fragment_is_decoded(self, mock_paste):
         """Test that URL without fragment is properly decoded."""
+        mock_paste.return_value = ""
         encoded_url = "https%3A%2F%2Fexample.com%2Fpath%2Fpage"
         expected_url = "https://example.com/path/page"
 
@@ -57,8 +61,10 @@ class TestPageMetadataUrlDecoding:
         assert metadata.url == expected_url
         assert metadata.parsed_url.fragment == ""
 
-    def test_url_with_query_string_is_decoded(self):
+    @patch("pyperclip.paste")
+    def test_url_with_query_string_is_decoded(self, mock_paste):
         """Test that URL with query string is properly decoded."""
+        mock_paste.return_value = ""
         encoded_url = "https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtest%2Bvalue"
         expected_url = "https://example.com/search?q=test+value"
 
@@ -67,8 +73,10 @@ class TestPageMetadataUrlDecoding:
 
         assert metadata.url == expected_url
 
-    def test_url_with_percent_in_fragment_is_decoded(self):
+    @patch("pyperclip.paste")
+    def test_url_with_percent_in_fragment_is_decoded(self, mock_paste):
         """Test that URL with %23 in fragment (encoded #) is decoded to #."""
+        mock_paste.return_value = ""
         # %23 is the URL-encoded form of #
         encoded_url = "https%3A%2F%2Fexample.com%2Fpage%23section%2Fsub"
         expected_url = "https://example.com/page#section/sub"
@@ -79,8 +87,10 @@ class TestPageMetadataUrlDecoding:
         assert metadata.url == expected_url
         assert metadata.parsed_url.fragment == "section/sub"
 
-    def test_url_already_decoded_is_unchanged(self):
+    @patch("pyperclip.paste")
+    def test_url_already_decoded_is_unchanged(self, mock_paste):
         """Test that already-decoded URL passes through unchanged."""
+        mock_paste.return_value = ""
         url = "https://example.com/path#fragment"
 
         mock_request = self._make_mock_request(url)
@@ -89,8 +99,10 @@ class TestPageMetadataUrlDecoding:
         assert metadata.url == url
         assert metadata.parsed_url.fragment == "fragment"
 
-    def test_empty_url_handled(self):
+    @patch("pyperclip.paste")
+    def test_empty_url_handled(self, mock_paste):
         """Test that empty URL is handled gracefully."""
+        mock_paste.return_value = ""
         mock_request = self._make_mock_request("")
         metadata = PageMetadata(request=mock_request)
 

--- a/web-tool.py
+++ b/web-tool.py
@@ -466,9 +466,11 @@ def get_mirror_links():
     fragment_variants = []
     fragment_variants_data = [
         ('', 'None'),
-        (metadata.parsed_url.fragment if metadata.parsed_url else '', 'Fragment'),
-        (metadata.fragment_text, 'Fragment Text'),
     ]
+    if metadata.parsed_url.fragment:
+        fragment_variants_data.append((metadata.parsed_url.fragment, 'Fragment'))
+    if metadata.fragment_text:
+        fragment_variants_data.append((metadata.fragment_text, 'Fragment Text'))
 
     seen_values = set()
     for fragment_value, label in fragment_variants_data:


### PR DESCRIPTION
## Summary
- Only show favicons that resolve to valid images (fixes broken favicon URLs being displayed)
- Only show fragment section when URL actually has a fragment
- Fix URL encoding in bookmarklet for URLs with `#` in fragment
- URL-decode URL in PageMetadata before parsing to fix double-encoding
- Fix JavaScript string escaping in template using `|tojson` filter

## Test plan
- [x] All 241 tests pass
- [ ] Manual testing with URLs like `https://pydantic.com.cn/en/api/json_schema/#pydantic.json_schema.GenerateJsonSchema.build_schema_type_to_method`
- [ ] Manual testing with URLs that have no fragment (fragment section should not appear)
- [ ] Manual testing with URLs that have broken favicons (favicon section should not appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)