### PR TITLE
Fix Markdown URL encoding and remove committed dev artifact

### DIFF
--- a/local-cache/favicon.yml
+++ b/local-cache/favicon.yml
@@ -1,4 +1,0 @@
-crummy.com/software: https://www.crummy.com/favicon.ico
-pandas.pydata.org/pandas-docs: https://pandas.pydata.org/pandas-docs/stable/_static/favicon.ico
-pydantic.com.cn/en: https://pydantic.com.cn/favicon.png
-ubuntu.com/cloud: https://ubuntu.com/favicon.png

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -172,7 +172,7 @@
             faviconOption: 'url'  // Will be overridden by DOMContentLoaded from checked radio
         };
 
-        // Function to escape text for safe use in URLs and HTML
+        // Function to escape text for safe use in HTML
         function escapeHtml(text) {
             const div = document.createElement('div');
             div.textContent = text;

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -241,8 +241,6 @@
 
         // Function to render the current state to the DOM
         function render() {
-            const linkText = buildLinkText(state.title, state.fragmentText);
-
             // HTML format
             const htmlLink = buildHtmlLink(state.title, state.fragmentText, state.url, state.faviconOption);
             document.getElementById('format-html-display').innerHTML = htmlLink;

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -219,8 +219,12 @@
             const linkText = escapeMarkdownText(buildLinkText(title, fragmentText));
             // Wrap URL in angle brackets if it contains chars that could
             // confuse the Markdown parser's link delimiter detection.
-            const wrappedUrl = MARKDOWN_URL_SAFE_WRAP_CHARS.test(url) ? `<${url}>` : url;
-            return `[${linkText}](${wrappedUrl})`;
+            // Encode < and > so they don't prematurely terminate the wrapped destination.
+            if (MARKDOWN_URL_SAFE_WRAP_CHARS.test(url)) {
+                const encoded = url.replace(/[<>]/g, (c) => encodeURIComponent(c));
+                return `[${linkText}](<${encoded}>)`;
+            }
+            return `[${linkText}](${url})`;
         }
 
         // Function to build a link in Wiki-link format

--- a/tests/test_js_escaping.py
+++ b/tests/test_js_escaping.py
@@ -167,8 +167,8 @@ class TestMirrorLinksJsEscaping:
         assert "MARKDOWN_URL_SAFE_WRAP_CHARS" in rendered
         # Should contain the Markdown text escape function
         assert "escapeMarkdownText" in rendered
-        # Should contain the updated buildMarkdownLink that uses angle-bracket wrapping
-        assert "wrappedUrl" in rendered
+        # Should contain the updated buildMarkdownLink that encodes < > in wrapped URLs
+        assert "encoded" in rendered or "encodeURIComponent" in rendered
 
     def test_markdown_link_template_has_url_wrapping_logic(self, template_env):
         """Test that buildMarkdownLink in the template uses angle-bracket URL wrapping."""
@@ -184,9 +184,8 @@ class TestMirrorLinksJsEscaping:
             favicon_inline=None,
         )
 
-        # The template should define the regex and use it in buildMarkdownLink
-        # The regex pattern [()[] <] should appear (with spaces collapsed)
-        assert "<${url}" in rendered or "<\" + url + \">" in rendered
+        # The template should use angle-bracket wrapping with < > encoding
+        assert "encodeURIComponent" in rendered
 
 
 if __name__ == "__main__":

--- a/tests/test_js_escaping.py
+++ b/tests/test_js_escaping.py
@@ -168,7 +168,7 @@ class TestMirrorLinksJsEscaping:
         # Should contain the Markdown text escape function
         assert "escapeMarkdownText" in rendered
         # Should contain the updated buildMarkdownLink that encodes < > in wrapped URLs
-        assert "encoded" in rendered or "encodeURIComponent" in rendered
+        assert "encodeURIComponent" in rendered
 
     def test_markdown_link_template_has_url_wrapping_logic(self, template_env):
         """Test that buildMarkdownLink in the template uses angle-bracket URL wrapping."""

--- a/tests/test_markdown_escaping.py
+++ b/tests/test_markdown_escaping.py
@@ -26,8 +26,11 @@ def escape_markdown_text(text: str) -> str:
 def build_markdown_link(title: str, fragment_text: str, url: str) -> str:
     """Build a Markdown link, applying escaping rules."""
     link_text = escape_markdown_text(fragment_text + " - " + title if fragment_text else title)
-    wrapped_url = f"<{url}>" if MARKDOWN_URL_SAFE_WRAP_CHARS.search(url) else url
-    return f"[{link_text}]({wrapped_url})"
+    if MARKDOWN_URL_SAFE_WRAP_CHARS.search(url):
+        # Encode < > so they don't terminate the wrapped destination early.
+        encoded = url.replace("<", "%3C").replace(">", "%3E")
+        return f"[{link_text}](<{encoded}>)"
+    return f"[{link_text}]({url})"
 
 
 class TestEscapeMarkdownText:
@@ -108,9 +111,10 @@ class TestMarkdownUrlWrapping:
         assert MARKDOWN_URL_SAFE_WRAP_CHARS.search("https://example.com/foo bar") is not None
 
     def test_url_with_angle_bracket_less_than_wrapped(self):
-        """URL containing < is wrapped; > is not in the wrapping regex."""
+        """URL containing < is wrapped; < and > are encoded inside the wrapped URL."""
         assert MARKDOWN_URL_SAFE_WRAP_CHARS.search("https://example.com/foo<bar") is not None
-        assert MARKDOWN_URL_SAFE_WRAP_CHARS.search("https://example.com/foo>bar") is None
+        result = build_markdown_link("", "", "https://example.com/foo<bar")
+        assert "<https://example.com/foo%3Cbar>" in result
 
     def test_fragment_with_parens_gets_wrapped(self):
         """URL with fragment containing parens (common with JS method names) is wrapped."""

--- a/tests/test_markdown_escaping.py
+++ b/tests/test_markdown_escaping.py
@@ -116,6 +116,11 @@ class TestMarkdownUrlWrapping:
         result = build_markdown_link("", "", "https://example.com/foo<bar")
         assert "<https://example.com/foo%3Cbar>" in result
 
+    def test_url_with_both_angle_brackets_encoded(self):
+        """URL containing both < and > is wrapped and both chars are percent-encoded."""
+        result = build_markdown_link("", "", "https://example.com/foo<bar>baz")
+        assert "<https://example.com/foo%3Cbar%3Ebaz>" in result
+
     def test_fragment_with_parens_gets_wrapped(self):
         """URL with fragment containing parens (common with JS method names) is wrapped."""
         url = "https://example.com/page#section(method)"


### PR DESCRIPTION
## Summary
- **Remove `local-cache/favicon.yml`** from git tracking — the `local-cache/` directory is gitignored and this file was accidentally committed in PR #21
- **Encode `<` and `>`** inside angle-bracket-wrapped Markdown link destinations using `encodeURIComponent` so they don't prematurely terminate the destination
- **Remove dead code** — unused `linkText` variable in `render()` function
- **Clarify comment** on `escapeHtml` — only escapes HTML, not URLs
- **Update Python tests** to mirror the JS `< >` encoding behavior

## Changes
- `templates/mirror-links.html` — 2 fixes + 1 dead code removal
- `tests/test_markdown_escaping.py` — mirror `< >` encoding, update test assertions
- `tests/test_js_escaping.py` — update test assertions to match refactored code
- `web-tool.py` — no code changes (inline favicon behavior kept as-is per discussion)

## Test plan
- [x] All 273 tests pass
- [x] JS and Python escaping logic verified in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)