### PR TITLE
Fix test-page template, conftest, and integration test issues

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -173,9 +173,9 @@ Tests for JavaScript string escaping in `mirror-links.html` template:
 - Favicon URL renders as JavaScript string
 
 #### `TestFragmentResolution` (4 integration tests)
-Tests fragment text resolution via the 6 handlers in `PageMetadata`:
+Tests fragment text resolution via fragment handlers in `PageMetadata`:
 - Heading with id resolves fragment to heading text
-- Anchor inside heading with href resolves to heading text minus anchor symbol
+- Anchor inside heading with href resolves to heading text (minus anchor symbol when anchor text trails the heading text)
 - Section/div wrapper with id containing heading resolves fragment
 - Anchor with matching href and text content resolves fragment
 

--- a/templates/test-page.html
+++ b/templates/test-page.html
@@ -12,8 +12,7 @@
     {# Anchor inside heading - for anchor-inside-heading fragment handler #}
     {% if anchor_fragment %}
     <h2 id="{{ anchor_fragment | e }}">
-        <a id="{{ anchor_fragment | e }}"></a>
-        {{ anchor_fragment | e }} with anchor
+        {{ anchor_fragment | e }} with anchor <a href="#{{ anchor_fragment | e }}">¶</a>
     </h2>
     {% endif %}
 
@@ -73,7 +72,7 @@
 
     {# Sibling heading after anchor - for anchor-siblings fragment handler #}
     <h3 id="sibling-heading">Sibling Heading</h3>
-    <a id="anchor-sibling"></a>
+    <a href="#sibling-heading" id="anchor-sibling">¶</a>
     <p>Content after the anchor.</p>
 
 </body>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,8 @@ def _load_web_tool():
     """Load web-tool.py as a module despite the hyphenated name."""
     app_path = Path(__file__).resolve().parent.parent / "web-tool.py"
     spec = spec_from_file_location("web_tool", app_path)
-    if spec.loader is None:
-        raise ImportError(f"Could not load loader for {app_path}")
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load loader for {app_path} (from {__file__})")
     web_tool = module_from_spec(spec)
     spec.loader.exec_module(web_tool)
     return web_tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,20 @@ Provides:
 - test_page_builder: helper to build test page URLs with query params
 """
 
-import importlib.util
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from urllib.parse import urlencode
 
 import pytest
 
 
 def _load_web_tool():
     """Load web-tool.py as a module despite the hyphenated name."""
-    spec = importlib.util.spec_from_file_location("web_tool", "web-tool.py")
-    web_tool = importlib.util.module_from_spec(spec)
+    app_path = Path(__file__).resolve().parent.parent / "web-tool.py"
+    spec = spec_from_file_location("web_tool", app_path)
+    if spec.loader is None:
+        raise ImportError(f"Could not load loader for {app_path}")
+    web_tool = module_from_spec(spec)
     spec.loader.exec_module(web_tool)
     return web_tool
 
@@ -50,12 +55,9 @@ def test_page_builder(base_url):
     def _build_url(**params):
         if not params:
             return base_url
-        query_parts = []
-        for key, value in params.items():
-            if value is not None and value != "":
-                query_parts.append(f"{key}={value}")
-        if not query_parts:
+        filtered = {k: v for k, v in params.items() if v is not None and v != ""}
+        if not filtered:
             return base_url
-        return f"{base_url}?{'&'.join(query_parts)}"
+        return f"{base_url}?{urlencode(filtered, doseq=True)}"
 
     return _build_url

--- a/tests/test_integration_pages.py
+++ b/tests/test_integration_pages.py
@@ -22,17 +22,10 @@ def _submit_clipboard(client, url, title, html, batch_id=None, user_agent="Test 
     Submit clipboard data to the clip-collector endpoint.
 
     Returns the batch_id and the JSON-encoded clipboard length.
-    batch_id must be a valid UUID string.
+    batch_id is optional and will be auto-generated if not provided.
     """
     if batch_id is None:
         batch_id = str(uuid.uuid4())
-    else:
-        # Validate it looks UUID-ish to avoid cryptic errors
-        try:
-            uuid.UUID(batch_id)
-        except ValueError:
-            # Not a valid UUID - generate a proper one
-            batch_id = str(uuid.uuid4())
 
     clip_data = {
         "url": url,
@@ -66,7 +59,7 @@ def _get_mirror_links(client, url, batch_id, text_length):
 
 @pytest.mark.integration
 class TestFragmentResolution:
-    """Tests for fragment text resolution via the 6 handlers in PageMetadata."""
+    """Tests for fragment text resolution via fragment handlers in PageMetadata."""
 
     def test_fragment_handler_heading_with_id(self, app_client, test_page_builder):
         """Heading element with matching id resolves fragment to heading text."""
@@ -132,7 +125,7 @@ class TestTitleVariants:
         url = "http://localhost/test"
         title = "日本語タイトル — Russian"
         html = f"<html><head><title>{title}</title></head><body><h1>{title}</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "test-title-unicode")
+        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "550e8400-e29b-41d4-a716-446655440001")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -144,7 +137,7 @@ class TestTitleVariants:
         url = "http://localhost/test"
         title = "Hello 🌍 World 🚀"
         html = f"<html><head><title>{title}</title></head><body><h1>{title}</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "test-title-emoji")
+        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "550e8400-e29b-41d4-a716-446655440002")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -160,7 +153,7 @@ class TestTitleVariants:
         url = "http://localhost/test"
         title = "File: Name [v1].txt"
         html = f"<html><head><title>{title}</title></head><body><h1>{title}</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "test-title-path")
+        batch_id, text_len = _submit_clipboard(app_client, url, title, html, "550e8400-e29b-41d4-a716-446655440003")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -177,7 +170,7 @@ class TestURLVariants:
         """URL Clean variant removes fragment and query string."""
         url = "http://example.com/path?query=value#section"
         html = "<html><body><h1>Test</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "test-url-clean")
+        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "550e8400-e29b-41d4-a716-446655440004")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -191,7 +184,7 @@ class TestURLVariants:
         """URL Root returns scheme://netloc/first-path-segment."""
         url = "http://example.com/a/b/c?query=1#frag"
         html = "<html><body><h1>Test</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "test-url-root")
+        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "550e8400-e29b-41d4-a716-446655440005")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -202,7 +195,7 @@ class TestURLVariants:
         """URL Host returns only scheme://netloc with no path."""
         url = "http://example.com/deep/path/file.html"
         html = "<html><body><h1>Test</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "test-url-host")
+        batch_id, text_len = _submit_clipboard(app_client, url, "Test", html, "550e8400-e29b-41d4-a716-446655440006")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -218,7 +211,9 @@ class TestMirrorLinksEndpoint:
         """mirror-links accepts batchId parameter for clipboard data."""
         url = "http://localhost/test"
         html = "<html><body><h1>Test</h1></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, "Test Title", html, "test-batch")
+        batch_id, text_len = _submit_clipboard(
+            app_client, url, "Test Title", html, "550e8400-e29b-41d4-a716-446655440000"
+        )
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -230,7 +225,7 @@ class TestMirrorLinksEndpoint:
             "<html><head><title>My Test Page</title></head>"
             "<body><h1>My Test Page</h1></body></html>"
         )
-        batch_id, text_len = _submit_clipboard(app_client, url, "My Test Page", html, "test-html")
+        batch_id, text_len = _submit_clipboard(app_client, url, "My Test Page", html, "550e8400-e29b-41d4-a716-446655440007")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -241,7 +236,7 @@ class TestMirrorLinksEndpoint:
         """mirror-links handles emoji in page content."""
         url = "http://localhost/test"
         html = "<html><body><h1>Emoji Test 🚀</h1><p>Navigation 📍 icons 🚀</p></body></html>"
-        batch_id, text_len = _submit_clipboard(app_client, url, "Emoji Test 🚀", html, "test-emoji")
+        batch_id, text_len = _submit_clipboard(app_client, url, "Emoji Test 🚀", html, "550e8400-e29b-41d4-a716-446655440008")
 
         resp = _get_mirror_links(app_client, url, batch_id, text_len)
         assert resp.status_code == 200
@@ -275,7 +270,7 @@ class TestTestPageEndpoint:
         assert resp.status_code == 200
         html = resp.get_data(as_text=True)
         assert 'id="my-anchor"' in html
-        assert '<a id="my-anchor"></a>' in html
+        assert '<a href="#my-anchor">' in html
 
     def test_test_page_with_wrap_fragment(self, app_client):
         """test-page renders wrapper section when wrap-fragment is set."""

--- a/tests/test_integration_pages.py
+++ b/tests/test_integration_pages.py
@@ -23,6 +23,7 @@ def _submit_clipboard(client, url, title, html, batch_id=None, user_agent="Test 
 
     Returns the batch_id and the JSON-encoded clipboard length.
     batch_id is optional and will be auto-generated if not provided.
+    A provided batch_id must be a valid UUID string (the server validates it).
     """
     if batch_id is None:
         batch_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary
- **conftest**: resolve `web-tool.py` path relative to `__file__`, add defensive loader check, use `urlencode` for query params
- **test-page.html**: fix duplicate id on anchor (use `href=#` instead of `id`-only), fix `anchor-siblings` anchor to include `href` so `_find_fragment_anchor` finds it
- **test_integration_pages**: remove silent UUID fallback that hid test bugs, replace invalid `batch_id` strings with valid UUIDs, update assertions
- **TESTING.md**: fix docstring overcount ("6 handlers" → "fragment handlers"), clarify conditional anchor-stripping behavior

## Test plan
- [x] All 294 tests pass