### PR TITLE
Dockerfile: add .dockerignore, non-root user, healthcheck, and optimizations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Python / venv
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Node
+node_modules/
+
+# Git
+.git/
+.gitignore
+.github/
+
+# Docs & testing
+TESTING.md
+TEST_COVERAGE.md
+CLAUDE.md
+Makefile
+docs/
+
+# Development artifacts
+tests/
+.env
+.env.*
+*.log
+
+# Build cache
+local-cache/
+
+# Not needed for runtime
+requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ local-cache/
 uv.lock
 .factory/
 .remember/
+
+# Node (not used by this Python project but sometimes present)
+node_modules/
+package.json
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv from official image (avoids extra pip layer)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ COPY web-tool.py README.md ./
 # Install deps
 RUN uv pip install --system --no-cache .
 
-# Non-root user for security (create before nltk download so data goes to their home)
+# Non-root user for security
 RUN useradd --create-home appuser && \
     chown -R appuser:appuser /app && \
     mkdir -p /data && chown appuser:appuser /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,39 @@
 FROM python:3.13-slim
 
-# Cairo is required for SVG conversion.
+# Install system deps + clean apt cache in one layer
 RUN apt-get update && \
-    apt-get install -y build-essential libcairo2-dev
+    apt-get install -y --no-install-recommends \
+        build-essential libcairo2-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv from official image (avoids extra pip layer)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-COPY web-tool.py .
-COPY README.md .
+# Copy all source + manifests before deps install (setuptools requires all package dirs present)
+COPY pyproject.toml uv.lock ./
 COPY library/ ./library/
 COPY static/ ./static/
 COPY templates/ ./templates/
-COPY pyproject.toml .
-COPY uv.lock .
+COPY web-tool.py README.md ./
 
-# Install uv
-RUN pip install --no-cache-dir uv
+# Install deps
+RUN uv pip install --system --no-cache .
 
-# Install dependencies using uv
-RUN uv pip install --system .
+# Non-root user for security (create before nltk download so data goes to their home)
+RUN useradd --create-home appuser && \
+    chown -R appuser:appuser /app && \
+    mkdir -p /data && chown appuser:appuser /data
 
-# Install NLTK data.
-RUN python -m nltk.downloader wordnet words
+# Download NLTK data to a world-readable location
+ENV NLTK_DATA=/usr/share/nltk_data
+RUN python -m nltk.downloader -d /usr/share/nltk_data wordnet words
+
+USER appuser
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/')" || exit 1
 
 EXPOSE 8532
 ENTRYPOINT ["python", "web-tool.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN python -m nltk.downloader -d /usr/share/nltk_data wordnet words
 USER appuser
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/', timeout=5).close()" || exit 1
 
 EXPOSE 8532
 ENTRYPOINT ["python", "web-tool.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY web-tool.py README.md ./
 RUN uv pip install --system --no-cache .
 
 # Non-root user for security
-RUN useradd --create-home appuser && \
+RUN useradd --uid 1000 --create-home appuser && \
     chown -R appuser:appuser /app && \
     mkdir -p /data && chown appuser:appuser /data
 

--- a/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
@@ -29,27 +29,33 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv from official image (avoids extra pip layer)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-
-# Copy dependency manifests first (for layer caching)
-COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --no-cache .
-
-# Download NLTK data (embedded in image)
-RUN python -m nltk.downloader wordnet words
+COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
 
 WORKDIR /app
-COPY web-tool.py README.md ./
+
+# Copy all source + manifests before deps install (setuptools requires all package dirs present)
+COPY pyproject.toml uv.lock ./
 COPY library/ ./library/
 COPY static/ ./static/
 COPY templates/ ./templates/
+COPY web-tool.py README.md ./
+
+# Install deps
+RUN uv pip install --system --no-cache .
 
 # Non-root user for security
-RUN useradd --create-home appuser && chown -R appuser:appuser /app
+RUN useradd --uid 1000 --create-home appuser && \
+    chown -R appuser:appuser /app && \
+    mkdir -p /data && chown appuser:appuser /data
+
+# Download NLTK data to a world-readable location
+ENV NLTK_DATA=/usr/share/nltk_data
+RUN python -m nltk.downloader -d /usr/share/nltk_data wordnet words
+
 USER appuser
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/', timeout=5).close()" || exit 1
 
 EXPOSE 8532
 ENTRYPOINT ["python", "web-tool.py"]

--- a/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
@@ -1,0 +1,78 @@
+# Dockerfile Improvement Design
+
+## Context
+
+The current `Dockerfile` is functional but has several issues that affect build performance, image size, and production readiness. This is a single-project repository (web-tool) used both locally and deployed to servers.
+
+## Design
+
+### 1. Add `.dockerignore`
+
+Exclude from build context:
+- `node_modules/`, `.venv/`, `.pytest_cache/`, `.git/`, `__pycache__/`, `*.pyc`
+- `TESTING.md`, `TEST_COVERAGE.md`, `Makefile`, `.github/`, `tests/`
+- `requirements.txt` (not used; uv managed)
+- `local-cache/` (runtime cache, not needed in image)
+- `*.yml`, `*.yaml` at root level (e.g., `CLAUDE.md`); files in `static/` are still needed
+
+**Impact**: Build context shrinks significantly; only actual runtime artifacts sent to Docker daemon.
+
+### 2. Optimized Single-Stage Dockerfile
+
+```
+FROM python:3.13-slim
+
+# Install system deps + clean apt cache in one layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential libcairo2-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv from official image (avoids extra pip layer)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy dependency manifests first (for layer caching)
+COPY pyproject.toml uv.lock ./
+RUN uv pip install --system --no-cache .
+
+# Download NLTK data (embedded in image)
+RUN python -m nltk.downloader wordnet words
+
+WORKDIR /app
+COPY web-tool.py README.md ./
+COPY library/ ./library/
+COPY static/ ./static/
+COPY templates/ ./templates/
+
+# Non-root user for security
+RUN useradd --create-home appuser && chown -R appuser:appuser /app
+USER appuser
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8532/')" || exit 1
+
+EXPOSE 8532
+ENTRYPOINT ["python", "web-tool.py"]
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|---|---|
+| `--no-install-recommends` | Don't pull suggested packages we don't need |
+| `apt-get clean && rm -rf /var/lib/apt/lists/*` | Keeps layer small; can't prune after layer commits |
+| `COPY --from=ghcr.io/astral-sh/uv:latest` | Official uv image is tiny; avoids `pip install uv` extra layer |
+| `uv pip install --system --no-cache` | No pip cache in image |
+| `USER appuser` | Runs as non-root; Flask still binds to 8532 fine |
+| Inline `HEALTHCHECK` | Built-in Docker health probe |
+
+## Files to Create/Modify
+
+- **Create**: `.dockerignore`
+- **Modify**: `Dockerfile`
+
+## Expected Outcomes
+
+- **Image size**: ~180-220MB (vs current ~250-300MB)
+- **Build time**: ~20-30% faster due to `.dockerignore` + better layer caching
+- **Production ready**: Non-root user + healthcheck included

--- a/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-07-dockerfile-improvement-design.md
@@ -13,7 +13,7 @@ Exclude from build context:
 - `TESTING.md`, `TEST_COVERAGE.md`, `Makefile`, `.github/`, `tests/`
 - `requirements.txt` (not used; uv managed)
 - `local-cache/` (runtime cache, not needed in image)
-- `*.yml`, `*.yaml` at root level (e.g., `CLAUDE.md`); files in `static/` are still needed
+- `docs/` (documentation not needed at runtime)
 
 **Impact**: Build context shrinks significantly; only actual runtime artifacts sent to Docker daemon.
 
@@ -61,9 +61,9 @@ ENTRYPOINT ["python", "web-tool.py"]
 |---|---|
 | `--no-install-recommends` | Don't pull suggested packages we don't need |
 | `apt-get clean && rm -rf /var/lib/apt/lists/*` | Keeps layer small; can't prune after layer commits |
-| `COPY --from=ghcr.io/astral-sh/uv:latest` | Official uv image is tiny; avoids `pip install uv` extra layer |
+| `COPY --from=ghcr.io/astral-sh/uv:0.11.3` | Official uv image is tiny; avoids `pip install uv` extra layer; pinned for reproducibility |
 | `uv pip install --system --no-cache` | No pip cache in image |
-| `USER appuser` | Runs as non-root; Flask still binds to 8532 fine |
+| `USER appuser` (uid 1000) | Runs as non-root; Flask still binds to 8532 fine; UID pinned for deterministic permissions |
 | Inline `HEALTHCHECK` | Built-in Docker health probe |
 
 ## Files to Create/Modify


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to exclude build artifacts (`node_modules/`, `.venv/`, `.pytest_cache/`, `tests/`, etc.) from Docker build context
- Run container as non-root `appuser` for security
- Add Docker `HEALTHCHECK` for production readiness
- Copy uv from official image instead of `pip install uv` (saves one layer)
- Clean apt cache in same layer as package install (smaller image)
- Download NLTK data to `/usr/share/nltk_data` (world-readable)

## Test plan
- [x] `make test` — 294 tests pass
- [x] `docker build -t web-tool:test .` — builds successfully
- [x] `docker run -p 8533:8532 web-tool:test` — container starts, responds HTTP 200
- [x] Container runs as non-root user (`uid=1000 appuser`)
- [x] Healthcheck configured

🤖 Generated with [Claude Code](https://claude.ai/claude-code)