### PR TITLE
feat: add paste favicon and inline image debug page

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Container detection status and clipboard proxy testing are available at:
     - Enter any URL and click Generate to see all variants (Original, With Fragment, Clean, Root, Host).
     - Duplicate variants are visually indicated with reduced opacity and gray background.
 
+- <a href="http://localhost:8532/debug/inline-image" target="_blank">inline image</a>
+    - Convert pasted or uploaded images to inline base64 `<img>` tags.
+    - Adjustable output height; useful for generating favicon-style inline images.
+
 - <a href="http://localhost:8532/test-pages-interactive" target="_blank">test pages</a>
     - <strong><a href="http://localhost:8532/test-pages-interactive" target="_blank">Interactive test page builder</a></strong> — configure parameters and load test pages in the browser
     - <a href="http://localhost:8532/test-page" target="_blank">Raw test page</a> — parameterized endpoint for direct URL access

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -432,10 +432,12 @@ For each segment, displays:
 - Automatically retrieves first cached favicon for the page domain
 - If no favicon cached: Automatically caches the top favicon for future use
 - Uses [favicon cache system](#favicon-system) with three-tier priority
+- **Paste Favicon:** Button reads a clipboard image via the `paste` event (no browser permission required), sends it to `POST /debug/inline-image`, and adds it as an inline base64 option in the favicon selector. Arms a 5-second timeout or Esc to cancel.
 
 **Favicon Display:**
 - Favicon images use `height="20"` with aspect ratio preserved
-- Inline base64 option shown only when favicon is stored with inline data in cache
+- Inline base64 option shown when favicon is stored with inline data in cache
+- **Pasted** option shown when a pasted image has been captured in the current session
 - URL option copies just the URL; Inline option copies full `<img>` tag with base64 data
 
 **Implementation:** [web-tool.py](web-tool.py) - `get_mirror_links()` function; [library/util.py](library/util.py) - `TitleVariants` class; [library/url_util.py](library/url_util.py) - URL parsing functions
@@ -827,6 +829,68 @@ Each favicon shows which cache file it comes from:
 **Use Case:** Debugging favicon not found issues, checking cache file status, verifying cache precedence, monitoring cache sizes
 
 **Implementation:** [web-tool.py](web-tool.py) - `debug_favicon_files()` function; [library/html_util.py](library/html_util.py) - cache file management functions
+
+#### `GET /debug/inline-image` — Inline Image Generator
+
+**Purpose:** Interactive debug page for converting pasted or uploaded images to inline base64 `<img>` tags. Useful for generating favicon-style inline images without network requests.
+
+**Features:**
+- Paste an image from clipboard (Ctrl+V) or use the file upload input
+- Adjustable output height (default 20px, preserving aspect ratio)
+- Shows the resulting `<img>` tag and raw base64 for direct use
+- 5MB client-side size guard; 2000px server-side dimension limit
+- Supports SVG, ICO, PNG, JPEG, WebP, and GIF inputs
+
+**Use Case:** Creating inline favicon images for mirror-links.html without fetching from a URL.
+
+**Implementation:** [web-tool.py](web-tool.py) - `debug_inline_image()` function; [library/img_util.py](library/img_util.py) - `encode_image_inline()` function
+
+#### `POST /debug/inline-image` — Convert Image to Inline Base64
+
+**Purpose:** Accepts a raw image (uploaded or base64-decoded) and returns a resized inline `<img>` tag.
+
+**Request:** `Content-Type: multipart/form-data`
+- `image` (required): Image file upload OR
+- `base64` (required): Base64-encoded image string
+
+**Request (JSON):** `Content-Type: application/json`
+- `base64` (required): Base64-encoded image string
+
+**Query Parameters:**
+- `height` (optional): Target height in pixels (default: 20, max: 200)
+
+**Response (JSON):**
+```json
+{
+  "success": true,
+  "inline": "<img src=\"data:image/png;base64,...\" height=\"20\" alt=\"Inline\" />",
+  "base64": "...",
+  "width": 24,
+  "height": 20,
+  "original_width": 48,
+  "original_height": 40,
+  "format": "PNG"
+}
+```
+
+**Error Response (JSON):**
+```json
+{ "success": false, "error": "error message" }
+```
+
+**Processing:**
+- Detects image type using Magika
+- Converts SVG to PNG via CairoSVG (256×256)
+- Resizes to target height (width clamped to 20× height to prevent huge base64 strings)
+- Returns base64-encoded PNG data URL
+
+**Error Conditions:**
+- 400: Missing image/base64 parameter
+- 400: Image dimensions exceed 2000×2000
+- 400: Unsupported image format
+- 500: Image processing failed
+
+**Implementation:** [web-tool.py](web-tool.py) - `debug_inline_image()` function; [library/img_util.py](library/img_util.py) - `encode_image_inline()` function
 
 ---
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -847,29 +847,18 @@ Each favicon shows which cache file it comes from:
 
 #### `POST /debug/inline-image` — Convert Image to Inline Base64
 
-**Purpose:** Accepts a raw image (uploaded or base64-decoded) and returns a resized inline `<img>` tag.
+**Purpose:** Accepts a base64-encoded image and returns a resized inline `<img>` tag.
 
-**Request:** `Content-Type: multipart/form-data`
-- `image` (required): Image file upload OR
-- `base64` (required): Base64-encoded image string
-
-**Request (JSON):** `Content-Type: application/json`
-- `base64` (required): Base64-encoded image string
-
-**Query Parameters:**
-- `height` (optional): Target height in pixels (default: 20, max: 200)
+**Request:** `Content-Type: application/json`
+- `image_data` (required): Base64-encoded image string
+- `height` (optional): Target height in pixels (default: 20, max: 200, must be 1–200)
 
 **Response (JSON):**
 ```json
 {
   "success": true,
-  "inline": "<img src=\"data:image/png;base64,...\" height=\"20\" alt=\"Inline\" />",
-  "base64": "...",
-  "width": 24,
-  "height": 20,
-  "original_width": 48,
-  "original_height": 40,
-  "format": "PNG"
+  "inline": "<img src=\"data:image/png;base64,...\" height=\"20\" alt=\"Favicon\" />",
+  "base64": "..."
 }
 ```
 
@@ -878,17 +867,16 @@ Each favicon shows which cache file it comes from:
 { "success": false, "error": "error message" }
 ```
 
+**Error Conditions:**
+- `400`: Missing or invalid JSON body, missing `image_data`, `height` out of range, invalid base64, image exceeds 5MB limit, unsupported format
+- `500`: Internal processing error
+
 **Processing:**
+- Decodes and validates base64 payload (max 5MB decoded)
 - Detects image type using Magika
 - Converts SVG to PNG via CairoSVG (256×256)
 - Resizes to target height (width clamped to 20× height to prevent huge base64 strings)
 - Returns base64-encoded PNG data URL
-
-**Error Conditions:**
-- 400: Missing image/base64 parameter
-- 400: Image dimensions exceed 2000×2000
-- 400: Unsupported image format
-- 500: Image processing failed
 
 **Implementation:** [web-tool.py](web-tool.py) - `debug_inline_image()` function; [library/img_util.py](library/img_util.py) - `encode_image_inline()` function
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO — Upcoming Work
+
+## PR: Docker improvements
+
+- [ ] Add script to run docker (e.g., `make docker-run` or a dedicated shell script)
+
+## PR: Inline image enhancements
+
+- [ ] Add width to images (currently only `height` is set on inline `<img>` tags; adding `width` can prevent layout shift)
+
+## PR: Fragment title handling
+
+- [ ] Fix fragment title (title extraction does not currently handle non-HTML content — see `library/util.py:369`)

--- a/docs/superpowers/plans/2026-04-08-paste-favicon-plan.md
+++ b/docs/superpowers/plans/2026-04-08-paste-favicon-plan.md
@@ -1,0 +1,224 @@
+# Implementation Plan: Paste Favicon / Inline Image
+
+## Overview
+
+Implement a paste-to-inline-favicon feature for mirror-links.html and a standalone debug page `/debug/inline-image` for converting pasted or uploaded images to inline base64 img tags.
+
+---
+
+## Step 1: Add `encode_image_inline()` to `library/img_util.py`
+
+**Files modified:** `library/img_util.py`
+
+Add a new function that takes raw image bytes (instead of a URL) and returns a base64 PNG data URL resized to the target height:
+
+```python
+def encode_image_inline(image_bytes: bytes, target_height: int = 20) -> str | None
+```
+
+Flow:
+1. Detect image type using `Magika` to confirm it's a supported image
+2. Open with `PIL.Image`
+3. Calculate new dimensions preserving aspect ratio (clamp width to `target_height * 20` to prevent huge base64)
+4. Resize using `Image.Resampling.LANCZOS`
+5. Save as PNG to `BytesIO` buffer → base64 → data URL
+
+**Note:** Mirrors existing `encode_favicon_inline()` pattern but accepts bytes instead of fetching a URL. The existing function could be refactored to call this new one.
+
+---
+
+## Step 2: Add `POST /debug/inline-image` endpoint
+
+**Files modified:** `web-tool.py`
+
+Add a new route following the pattern of existing debug routes:
+
+```python
+@app.route("/debug/inline-image", methods=["POST"])
+def debug_inline_image():
+    data = request.get_json()
+    image_data = data.get("image_data")  # base64 string
+    height = data.get("height", 20)
+
+    if not image_data:
+        return jsonify({"success": False, "error": "image_data is required"})
+
+    # Decode base64 → encode_image_inline → return
+```
+
+Returns:
+```json
+{"success": true, "inline": "<img src=\"data:image/png;base64,...\" height=\"20\" alt=\"Favicon\" />", "base64": "..."}
+```
+
+On error:
+```json
+{"success": false, "error": "description"}
+```
+
+---
+
+## Step 3: Create `static/js/paste-favicon.js`
+
+**Files created:** `static/js/paste-favicon.js`
+
+A small JS module for clipboard image handling:
+
+```javascript
+// Reads image/* from clipboard using Navigator.clipboard API
+// Returns Blob or null if clipboard empty / no image
+
+// Converts Blob to base64 string
+
+// Adds "Pasted" radio option to the mirror-links favicon section
+// and auto-selects it. The base64 image is stored in defaultValues.pastedFavicon.
+```
+
+Key functions:
+- `readClipboardImage()` → `Promise<Blob | null>`
+- `blobToBase64(blob)` → `Promise<string>`
+- `addPastedFavicon(base64Image, container)` → injects "Pasted" radio option
+
+Error handling: if clipboard has no image, show tooltip "No image in clipboard" on the Paste button.
+
+---
+
+## Step 4: Create `static/js/inline-image.js`
+
+**Files created:** `static/js/inline-image.js`
+
+JS for the debug page:
+
+```javascript
+// handlePaste(): reads clipboard image → blobToBase64 → send to server
+// handleFileUpload(file): FileReader → base64 → send to server
+// updatePreview(imgTag): renders output <img> in preview area
+// copyOutput(): copies generated <img> tag to clipboard with tooltip
+```
+
+Sends to `POST /debug/inline-image`, receives inline tag and base64, updates the DOM.
+
+---
+
+## Step 5: Create `templates/debug-inline-image.html`
+
+**Files created:** `templates/debug-inline-image.html`
+
+Following the style of `debug-title-variants.html`:
+
+```html
+<h1>Inline Image Generator</h1>
+
+<div class="metadata-panel">
+    <h2>Height</h2>
+    <input type="number" id="height-input" value="20" min="1" max="100"> px
+</div>
+
+<div class="metadata-panel">
+    <h2>Image</h2>
+    <div id="image-preview" style="min-height: 60px; border: 1px dashed #ccc; padding: 8px;">
+        <!-- Preview area -->
+    </div>
+    <div style="margin-top: 8px;">
+        <button id="paste-btn">Paste Image</button>
+        <span style="margin: 0 8px; color: #666;">or</span>
+        <input type="file" id="file-input" accept="image/*">
+    </div>
+</div>
+
+<div class="metadata-panel">
+    <h2>Output</h2>
+    <button class="copy-btn" id="copy-output">Copy</button>
+    <div id="output-tag" style="margin-top: 8px;"></div>
+    <div id="output-base64" style="margin-top: 8px; font-family: monospace; font-size: 0.85em; word-break: break-all;"></div>
+</div>
+```
+
+Links to `static/js/inline-image.js`.
+
+---
+
+## Step 6: Update `templates/mirror-links.html`
+
+**Files modified:** `templates/mirror-links.html`
+
+### Change 1: Always show favicon section
+
+Replace `{% if favicon %}...{% endif %}` with unconditional rendering.
+
+### Change 2: Favicon section structure
+
+Always starts with "None" selected. When page has favicons, shows URL and Inline options. Paste Favicon button is always last.
+
+```html
+<div class="favicon-section">
+    <h2>Favicon</h2>
+    <div class="url-list">
+        <div class="url-item">
+            <input type="radio" name="favicon_option" value="none" checked>
+            <span style="min-width: 100px;"><strong>None</strong></span>
+        </div>
+        {% if favicon %}
+        <div class="url-item">
+            <input type="radio" name="favicon_option" value="url">
+            ...URL option...
+        </div>
+        {% if favicon_inline %}
+        <div class="url-item">
+            <input type="radio" name="favicon_option" value="inline">
+            ...Inline option...
+        </div>
+        {% endif %}
+        {% endif %}
+        <div class="url-item">
+            <button id="paste-favicon-btn">Paste Favicon</button>
+            <span style="min-width: 100px;"><strong>Paste</strong></span>
+        </div>
+    </div>
+</div>
+```
+
+### Change 3: JavaScript state
+
+- Track `pastedFavicon` in `defaultValues` and `state`
+- Paste button click → `readClipboardImage()` → `addPastedFavicon()` → inject "Pasted" radio option and auto-select it
+- `buildHtmlLink()` handles `faviconOption === 'pasted'` using `defaultValues.pastedFavicon`
+- `render()` and radio change listeners updated to handle 'pasted'
+
+### Change 4: Link to `static/js/paste-favicon.js`
+
+Add `<script src="/static/js/paste-favicon.js"></script>` before the closing `</body>`.
+
+---
+
+## Step 7: Tests
+
+**Files created:** `tests/test_img_util.py` (extend existing)
+
+Add tests for `encode_image_inline()`:
+- Valid PNG bytes → returns base64 data URL
+- Valid JPEG bytes → returns base64 PNG data URL (converted)
+- SVG bytes → converts to PNG
+- Invalid bytes → returns None
+- Various target heights → dimensions correct
+
+---
+
+## Files Summary
+
+| File | Action |
+|------|--------|
+| `library/img_util.py` | Add `encode_image_inline()` |
+| `web-tool.py` | Add `POST /debug/inline-image` |
+| `static/js/paste-favicon.js` | Create |
+| `static/js/inline-image.js` | Create |
+| `templates/debug-inline-image.html` | Create |
+| `templates/mirror-links.html` | Modify favicon section |
+| `tests/test_img_util.py` | Add tests |
+
+## Dependencies
+
+- `cairosvg`, `PIL/Pillow`, `magika` — already in use by `encode_favicon_inline()`
+**Client-side size guard:** `Blob.size` or `File.size` checked before sending — reject if > 5MB. This is free with no image loading required.
+
+**Server-side dimension guard:** When Pillow opens the image, if either dimension > 2000px, return an error. Keeps client JS minimal.

--- a/library/img_util.py
+++ b/library/img_util.py
@@ -85,6 +85,8 @@ def _resize_image(img: Image.Image, target_height: int) -> Image.Image:
     Width is clamped to max 20x the target height to prevent huge base64
     strings from very wide images.
     """
+    if target_height < 1:
+        raise ValueError(f"target_height must be >= 1, got {target_height}")
     aspect_ratio = img.width / img.height
     new_height = target_height
     new_width = int(target_height * aspect_ratio)
@@ -93,6 +95,10 @@ def _resize_image(img: Image.Image, target_height: int) -> Image.Image:
     if new_width > max_width:
         new_width = max_width
         new_height = int(max_width / aspect_ratio)
+
+    # Clamp to at least 1 to prevent Pillow raising on non-positive dimensions.
+    new_width = max(1, new_width)
+    new_height = max(1, new_height)
 
     return img.resize((new_width, new_height), Image.Resampling.LANCZOS)
 

--- a/library/img_util.py
+++ b/library/img_util.py
@@ -79,6 +79,82 @@ def convert_svg(href: str, to_format: str = "PNG") -> bytes:
         return None
 
 
+def _resize_image(img: Image.Image, target_height: int) -> Image.Image:
+    """Resize an image to target_height preserving aspect ratio.
+
+    Width is clamped to max 20x the target height to prevent huge base64
+    strings from very wide images.
+    """
+    aspect_ratio = img.width / img.height
+    new_height = target_height
+    new_width = int(target_height * aspect_ratio)
+
+    max_width = target_height * 20
+    if new_width > max_width:
+        new_width = max_width
+        new_height = int(max_width / aspect_ratio)
+
+    return img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+
+
+def encode_image_inline(image_bytes: bytes, target_height: int = 20) -> str | None:
+    """Encode raw image bytes as a base64 PNG string, resized to target height.
+
+    Detects the image type using Magika, opens with Pillow, resizes to
+    target_height preserving aspect ratio (width clamped to 20x target_height
+    to prevent huge base64 strings), and returns a base64-encoded PNG data URL.
+
+    Args:
+        image_bytes: Raw bytes of the image file
+        target_height: Target height in pixels (default: 20)
+
+    Returns:
+        Base64-encoded PNG string (with data URL prefix) or None on failure
+    """
+    try:
+        # Detect image type
+        result = mgk.identify_bytes(image_bytes)
+        image_type = result.output.label
+        logging.debug(f"encode_image_inline: detected type={image_type}")
+
+        # Handle SVG — convert to PNG first
+        if image_type == "image/svg":
+            png_buffer = BytesIO()
+            svg2png(
+                bytestring=image_bytes,
+                write_to=png_buffer,
+                output_height=SVG_HEIGHT,
+                output_width=SVG_WIDTH,
+            )
+            image_bytes = png_buffer.getvalue()
+            image_type = "image/png"
+
+        # Check dimensions before loading into Pillow
+        temp_img = Image.open(BytesIO(image_bytes))
+        if temp_img.width > 2000 or temp_img.height > 2000:
+            logging.warning(
+                f"encode_image_inline: image too large {temp_img.width}x{temp_img.height}"
+            )
+            return None
+
+        # Open the image
+        img = Image.open(BytesIO(image_bytes))
+
+        # Resize preserving aspect ratio
+        resized = _resize_image(img, target_height)
+
+        # Convert to PNG and encode as base64
+        png_buffer = BytesIO()
+        resized.save(png_buffer, format="PNG")
+        png_bytes = png_buffer.getvalue()
+
+        b64 = base64.b64encode(png_bytes).decode("ascii")
+        return f"data:image/png;base64,{b64}"
+    except Exception as e:
+        logging.warning(f"Failed to encode image inline: {e}")
+        return None
+
+
 @lru_cache(maxsize=128)
 def encode_favicon_inline(href: str, target_height: int = 20) -> str | None:
     """Encode a favicon as a base64 PNG string, resized to target height.
@@ -98,32 +174,7 @@ def encode_favicon_inline(href: str, target_height: int = 20) -> str | None:
         resp = url_util.get_url(href)
         resp.raise_for_status()
 
-        # Open the image
-        img = Image.open(BytesIO(resp.content))
-
-        # Calculate new dimensions preserving aspect ratio
-        aspect_ratio = img.width / img.height
-        new_height = target_height
-        new_width = int(target_height * aspect_ratio)
-
-        # Clamp width to prevent huge base64 strings from very wide images
-        # Most favicons have reasonable aspect ratios; limit to 20x the height
-        max_width = target_height * 20
-        if new_width > max_width:
-            new_width = max_width
-            new_height = int(max_width / aspect_ratio)
-
-        # Resize using high-quality resampling
-        resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-
-        # Convert to PNG and encode as base64
-        png_buffer = BytesIO()
-        resized.save(png_buffer, format="PNG")
-        png_bytes = png_buffer.getvalue()
-
-        # Encode as base64 with data URL prefix
-        b64 = base64.b64encode(png_bytes).decode("ascii")
-        return f"data:image/png;base64,{b64}"
+        return encode_image_inline(resp.content, target_height)
     except Exception as e:
         logging.warning(f"Failed to encode favicon inline: {href} {e}")
         return None

--- a/library/img_util.py
+++ b/library/img_util.py
@@ -30,7 +30,7 @@ def convert_ico(href: str, to_format: str = "PNG") -> bytes | None:
         resp.raise_for_status()
 
         # Check if the response is an ICO image.
-        if t := resp.get_type() != "image/ico":
+        if (t := resp.get_type()) != "image/ico":
             logging.warning(f"Not an ICO file (magika): {href} {t}")
             return None
 

--- a/static/js/inline-image.js
+++ b/static/js/inline-image.js
@@ -1,0 +1,290 @@
+/**
+ * Inline Image Generator - debug page JS
+ *
+ * Uses the paste event (no browser permission required) after a button click.
+ * After clicking "Paste Image", the next Ctrl/Cmd+V anywhere on the page captures
+ * the image.
+ */
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const PASTE_TIMEOUT_MS = 5000; // 5 second window to paste after clicking
+
+let _pasteTimer = null;
+let _pasteHandler = null;
+let _pasteKeyHandler = null;
+
+/**
+ * Show a temporary tooltip on a button element.
+ * @param {HTMLElement} btn
+ * @param {string} message
+ */
+function showInlineTooltip(btn, message) {
+    const existing = btn.querySelector('.inline-tooltip');
+    if (existing) existing.remove();
+
+    const tooltip = document.createElement('span');
+    tooltip.className = 'inline-tooltip';
+    tooltip.textContent = message;
+    tooltip.style.cssText =
+        'position: absolute; background: #333; color: white; padding: 4px 8px; ' +
+        'border-radius: 4px; font-size: 12px; white-space: nowrap; z-index: 1000; ' +
+        'pointer-events: none; display: inline-block;';
+
+    const rect = btn.getBoundingClientRect();
+    tooltip.style.left = rect.left + 'px';
+    tooltip.style.top = (rect.top - 30) + 'px';
+
+    document.body.appendChild(tooltip);
+    setTimeout(() => tooltip.remove(), 2000);
+}
+
+/**
+ * Convert a Blob to a base64 string (no data URL prefix).
+ * @param {Blob} blob
+ * @returns {Promise<string>}
+ */
+function blobToBase64(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const base64 = reader.result.split(',', 2)[1];
+            resolve(base64);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(blob);
+    });
+}
+
+/**
+ * Read a File as a base64 string (no data URL prefix).
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+function fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const base64 = reader.result.split(',', 2)[1];
+            resolve(base64);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+    });
+}
+
+/**
+ * Send image data to the server and update the output display.
+ * @param {string} base64Image  Raw base64 string (no prefix)
+ * @param {number} height
+ * @returns {Promise<void>}
+ */
+async function sendToServer(base64Image, height) {
+    const response = await fetch('/debug/inline-image', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({image_data: base64Image, height: height}),
+    });
+
+    const data = await response.json();
+
+    if (data.success) {
+        updatePreview(data.inline, data.base64);
+        showInlineTooltip(document.getElementById('copy-output-btn'), 'Ready!');
+    } else {
+        showInlineTooltip(document.getElementById('copy-output-btn'), 'Error: ' + data.error);
+        clearPreview();
+    }
+}
+
+/**
+ * Update the output section with the generated img tag and raw base64.
+ * @param {string} imgTag  Complete <img .../> tag
+ * @param {string} base64  Raw base64 string
+ */
+function updatePreview(imgTag, base64) {
+    const outputTag = document.getElementById('output-tag');
+    const outputBase64 = document.getElementById('output-base64');
+    const copyBtn = document.getElementById('copy-output-btn');
+
+    if (outputTag) outputTag.innerHTML = imgTag;
+    if (outputBase64) outputBase64.textContent = base64;
+    if (copyBtn) {
+        copyBtn.dataset.html = imgTag;
+        copyBtn.disabled = false;
+    }
+}
+
+/**
+ * Clear the preview area.
+ */
+function clearPreview() {
+    const outputTag = document.getElementById('output-tag');
+    const outputBase64 = document.getElementById('output-base64');
+    const copyBtn = document.getElementById('copy-output-btn');
+
+    if (outputTag) outputTag.innerHTML = '';
+    if (outputBase64) outputBase64.textContent = '';
+    if (copyBtn) {
+        copyBtn.dataset.html = '';
+        copyBtn.disabled = true;
+    }
+}
+
+/**
+ * Copy the generated img tag to clipboard.
+ */
+async function copyOutput() {
+    const btn = document.getElementById('copy-output-btn');
+    const html = btn && btn.dataset.html;
+    if (!html) return;
+
+    try {
+        await navigator.clipboard.writeText(html);
+        showInlineTooltip(btn, 'Copied!');
+    } catch (err) {
+        showInlineTooltip(btn, 'Copy failed');
+    }
+}
+
+/**
+ * Disarm the paste listener and clear the timeout.
+ * @param {HTMLButtonElement} btn
+ */
+function disarmPaste(btn) {
+    if (_pasteHandler) {
+        document.removeEventListener('paste', _pasteHandler);
+        _pasteHandler = null;
+    }
+    if (_pasteKeyHandler) {
+        document.removeEventListener('keydown', _pasteKeyHandler);
+        _pasteKeyHandler = null;
+    }
+    if (_pasteTimer) {
+        clearTimeout(_pasteTimer);
+        _pasteTimer = null;
+    }
+    if (btn) {
+        btn.textContent = 'Paste Image';
+    }
+}
+
+/**
+ * Handle the Paste Image button click.
+ * Arms a one-time paste event listener. The next Ctrl/Cmd+V anywhere on the
+ * page will capture the image. The listener auto-disarms after 5 seconds.
+ */
+async function handlePaste() {
+    const btn = document.getElementById('paste-btn');
+    const height = parseInt(document.getElementById('height-input')?.value, 10) || 20;
+
+    // Disarm any previous paste session
+    disarmPaste(null);
+
+    showInlineTooltip(btn, 'Waiting for paste... (Esc to cancel)');
+    btn.textContent = 'Waiting...';
+
+    _pasteHandler = async (e) => {
+        e.preventDefault();
+        disarmPaste(btn);
+
+        const items = e.clipboardData?.items;
+        if (!items) {
+            showInlineTooltip(btn, 'No clipboard data');
+            return;
+        }
+
+        let imageBlob = null;
+        for (const item of items) {
+            if (item.kind === 'file' && item.type.startsWith('image/')) {
+                imageBlob = item.getAsFile();
+                break;
+            }
+        }
+
+        if (!imageBlob) {
+            showInlineTooltip(btn, 'No image in clipboard');
+            return;
+        }
+
+        if (imageBlob.size > MAX_FILE_SIZE) {
+            showInlineTooltip(btn, 'Image too large (max 5MB)');
+            return;
+        }
+
+        try {
+            const base64 = await blobToBase64(imageBlob);
+            showInlineTooltip(btn, 'Processing...');
+            await sendToServer(base64, height);
+            // Clear the file input so no filename is shown
+            document.getElementById('file-input').value = '';
+        } catch (err) {
+            console.error('handlePaste:', err);
+            showInlineTooltip(btn, 'Paste failed');
+        }
+    };
+
+    document.addEventListener('paste', _pasteHandler);
+
+    // Esc to cancel
+    _pasteKeyHandler = (e) => {
+        if (e.key === 'Escape') {
+            disarmPaste(btn);
+            showInlineTooltip(btn, 'Paste cancelled');
+        }
+    };
+    document.addEventListener('keydown', _pasteKeyHandler);
+
+    _pasteTimer = setTimeout(() => {
+        if (_pasteHandler) {
+            disarmPaste(btn);
+            showInlineTooltip(btn, 'Paste cancelled');
+        }
+    }, PASTE_TIMEOUT_MS);
+}
+
+/**
+ * Handle a file input change event.
+ * @param {File} file
+ */
+async function handleFileUpload(file) {
+    const height = parseInt(document.getElementById('height-input')?.value, 10) || 20;
+
+    if (!file || !file.type.startsWith('image/')) {
+        return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+        showInlineTooltip(document.getElementById('file-input'), 'Image too large (max 5MB)');
+        return;
+    }
+
+    const base64 = await fileToBase64(file);
+    await sendToServer(base64, height);
+}
+
+/**
+ * Attach event listeners for the debug inline-image page.
+ */
+function attachListeners() {
+    const pasteBtn = document.getElementById('paste-btn');
+    if (pasteBtn) {
+        pasteBtn.addEventListener('click', handlePaste);
+    }
+
+    const fileInput = document.getElementById('file-input');
+    if (fileInput) {
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files && e.target.files[0];
+            if (file) handleFileUpload(file);
+        });
+    }
+
+    const copyBtn = document.getElementById('copy-output-btn');
+    if (copyBtn) {
+        copyBtn.disabled = true;
+        copyBtn.addEventListener('click', copyOutput);
+    }
+}
+
+// Auto-attach on DOMContentLoaded
+document.addEventListener('DOMContentLoaded', attachListeners);

--- a/static/js/paste-favicon.js
+++ b/static/js/paste-favicon.js
@@ -1,0 +1,286 @@
+/**
+ * Paste Favicon - clipboard image to base64 favicon option
+ *
+ * Uses the paste event (no browser permission required) after a button click.
+ * After clicking "Paste Favicon", the next Ctrl/Cmd+V (or Edit → Paste) anywhere
+ * on the page captures the image.
+ */
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const PASTE_TIMEOUT_MS = 5000; // 5 second window to paste after clicking
+
+let _pasteTimer = null; // timeout handle for paste window
+let _pasteHandler = null; // bound paste event handler
+let _pasteKeyHandler = null; // keydown handler for Esc cancel
+
+/**
+ * Show a temporary tooltip near the paste favicon button.
+ * Uses fixed positioning relative to the button, appended to body.
+ * @param {HTMLElement} btn
+ * @param {string} message
+ */
+function showPasteTooltip(btn, message) {
+    // Remove any existing tooltip
+    const existing = btn.querySelector('.paste-tooltip');
+    if (existing) existing.remove();
+
+    const tooltip = document.createElement('span');
+    tooltip.className = 'paste-tooltip';
+    tooltip.textContent = message;
+    tooltip.style.cssText =
+        'position: fixed; background: #333; color: white; padding: 4px 8px; ' +
+        'border-radius: 4px; font-size: 12px; white-space: nowrap; z-index: 9999; ' +
+        'pointer-events: none; display: block;';
+
+    const rect = btn.getBoundingClientRect();
+    // Position below the button, left-aligned
+    tooltip.style.left = rect.left + 'px';
+    tooltip.style.top = (rect.bottom + 4) + 'px';
+
+    document.body.appendChild(tooltip);
+
+    setTimeout(() => tooltip.remove(), 2000);
+}
+
+/**
+ * Convert a Blob to a base64 string (no data URL prefix).
+ * @param {Blob} blob
+ * @returns {Promise<string>}
+ */
+function blobToBase64(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const base64 = reader.result.split(',', 2)[1];
+            resolve(base64);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(blob);
+    });
+}
+
+/**
+ * Send image data to the server and return the resized inline data.
+ * @param {string} base64Image  Raw base64 string (no prefix)
+ * @returns {Promise<{inline: string, base64: string}>}
+ */
+async function sendToServer(base64Image) {
+    const response = await fetch('/debug/inline-image', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({image_data: base64Image, height: 20}),
+    });
+    const data = await response.json();
+    if (!data.success) {
+        throw new Error(data.error || 'Server error');
+    }
+    return data; // {inline: '<img...>', base64: '...'}
+}
+
+/**
+ * Add a "Pasted" favicon option to the mirror-links favicon section.
+ * Removes any existing "Pasted" option first.
+ * @param {string} base64Image  Base64 string (no data URL prefix)
+ * @param {HTMLElement} container  The .url-list div inside the favicon section
+ * @param {function(string): void} [onSelect]  Called when the pasted option is selected
+ */
+function addPastedFavicon(base64Image, container, onSelect) {
+    // Remove existing Pasted option if present
+    const existing = container.querySelector('.favicon-pasted-option');
+    if (existing) existing.remove();
+
+    // Create the pasted option div
+    const pastedDiv = document.createElement('div');
+    pastedDiv.className = 'url-item favicon-pasted-option';
+
+    // Build the full data URL for preview
+    const dataUrl = `data:image/png;base64,${base64Image}`;
+    const escapedDataUrl = escapeHtml(dataUrl);
+    const escapedBase64 = escapeHtml(base64Image);
+
+    pastedDiv.innerHTML = `
+        <input type="radio" name="favicon_option" value="pasted">
+        <button class="copy-btn" data-html="&lt;img src=&quot;${escapedDataUrl}&quot; height=&quot;20&quot; alt=&quot;Favicon&quot; /&gt;">Copy</button>
+        <span style="min-width: 100px;"><strong>Pasted</strong></span>
+        <img src="${escapedDataUrl}" height="20" alt="Favicon" />
+        <span style="font-family: monospace; font-size: 0.85em; color: #666; word-break: break-all;">
+            ${truncateMiddle(escapedBase64, 60)}
+        </span>
+    `;
+
+    // Insert before the Paste button (last child minus 1)
+    const pasteBtn = container.querySelector('.paste-favicon-btn');
+    if (pasteBtn && pasteBtn.parentNode === container) {
+        container.insertBefore(pastedDiv, pasteBtn.parentNode);
+    } else {
+        container.appendChild(pastedDiv);
+    }
+
+    // Auto-select the pasted option
+    const radio = pastedDiv.querySelector('input[type="radio"]');
+    if (radio) {
+        radio.checked = true;
+    }
+
+    // Attach copy button listener
+    const copyBtn = pastedDiv.querySelector('.copy-btn');
+    if (copyBtn) {
+        copyBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(copyBtn.dataset.html).then(() => {
+                showPasteTooltip(copyBtn, 'Copied!');
+            });
+        });
+    }
+
+    // Notify state change
+    if (onSelect) {
+        onSelect('pasted');
+    }
+
+    // Update the global state and render
+    if (typeof state !== 'undefined') {
+        state.faviconOption = 'pasted';
+    }
+    if (typeof defaultValues !== 'undefined') {
+        defaultValues.pastedFavicon = dataUrl;
+    }
+    if (typeof render === 'function') {
+        render();
+    }
+}
+
+/**
+ * Escape text for safe use in HTML.
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Truncate a string in the middle with an ellipsis.
+ * @param {string} str
+ * @param {number} maxLen
+ * @returns {string}
+ */
+function truncateMiddle(str, maxLen) {
+    if (str.length <= maxLen) return str;
+    const half = Math.floor((maxLen - 3) / 2);
+    return str.slice(0, half) + '...' + str.slice(-half);
+}
+
+/**
+ * Disarm the paste listener and clear the timeout.
+ * @param {HTMLButtonElement} btn
+ */
+function disarmPaste(btn) {
+    if (_pasteHandler) {
+        document.removeEventListener('paste', _pasteHandler);
+        _pasteHandler = null;
+    }
+    if (_pasteKeyHandler) {
+        document.removeEventListener('keydown', _pasteKeyHandler);
+        _pasteKeyHandler = null;
+    }
+    if (_pasteTimer) {
+        clearTimeout(_pasteTimer);
+        _pasteTimer = null;
+    }
+    if (btn) {
+        btn.textContent = 'Paste Favicon';
+    }
+}
+
+/**
+ * Handle the Paste Favicon button click on mirror-links.html.
+ * Arms a one-time paste event listener. The next Ctrl/Cmd+V anywhere on the
+ * page will capture the image. The listener auto-disarms after 5 seconds.
+ * @param {HTMLButtonElement} btn
+ * @param {HTMLElement} container
+ */
+async function handlePasteFavicon(btn, container) {
+    // Disarm any previous paste session
+    disarmPaste(null);
+
+    btn.textContent = 'Waiting for paste... (Esc to cancel)';
+
+    // Build the paste handler
+    _pasteHandler = async (e) => {
+        // Prevent the default paste (no browser auto-insert)
+        e.preventDefault();
+
+        // Disarm immediately — single use only
+        disarmPaste(btn);
+        btn.textContent = 'Pasting...';
+
+        // Get image from clipboard
+        const items = e.clipboardData?.items;
+        if (!items) {
+            btn.textContent = 'Paste Failed';
+            showPasteTooltip(btn, 'No clipboard data');
+            return;
+        }
+
+        let imageBlob = null;
+        for (const item of items) {
+            if (item.kind === 'file' && item.type.startsWith('image/')) {
+                imageBlob = item.getAsFile();
+                break;
+            }
+        }
+
+        if (!imageBlob) {
+            btn.textContent = 'Paste Failed';
+            showPasteTooltip(btn, 'No image in clipboard');
+            return;
+        }
+
+        if (imageBlob.size > MAX_FILE_SIZE) {
+            btn.textContent = 'Paste Failed';
+            showPasteTooltip(btn, 'Image too large (max 5MB)');
+            return;
+        }
+
+        try {
+            const rawBase64 = await blobToBase64(imageBlob);
+
+            // Send to server — receives resized base64 at height=20
+            const data = await sendToServer(rawBase64);
+
+            addPastedFavicon(data.base64, container, (option) => {
+                if (typeof state !== 'undefined') {
+                    state.faviconOption = option;
+                }
+            });
+
+            btn.textContent = 'Pasted!';
+        } catch (err) {
+            console.error('handlePasteFavicon:', err);
+            btn.textContent = 'Paste Failed';
+            showPasteTooltip(btn, err.message || 'Paste failed');
+        }
+    };
+
+    // Attach the paste listener
+    document.addEventListener('paste', _pasteHandler);
+
+    // Esc to cancel
+    _pasteKeyHandler = (e) => {
+        if (e.key === 'Escape') {
+            disarmPaste(btn);
+            btn.textContent = 'Paste Favicon';
+        }
+    };
+    document.addEventListener('keydown', _pasteKeyHandler);
+
+    // Auto-disarm after timeout
+    _pasteTimer = setTimeout(() => {
+        if (_pasteHandler) {
+            disarmPaste(btn);
+            btn.textContent = 'Paste Favicon';
+        }
+    }, PASTE_TIMEOUT_MS);
+}

--- a/templates/debug-inline-image.html
+++ b/templates/debug-inline-image.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Debug Inline Image</title>
+    <link rel="stylesheet" href="/static/default.css">
+    <link rel="stylesheet" href="/static/mirror.css">
+    <style>
+        #file-input::file-selector-button {
+            padding: 8px 16px;
+            font-size: 14px;
+            border: none;
+            background: #0066cc;
+            color: white;
+            cursor: pointer;
+        }
+        #file-input::file-selector-button:hover {
+            background: #0052a3;
+        }
+    </style>
+</head>
+<body>
+    <h1>Inline Image Generator</h1>
+    <p>Convert a pasted or uploaded image to an inline base64 img tag.</p>
+
+    <div class="metadata-panel">
+        <h2>Height</h2>
+        <div style="display: flex; gap: 10px; align-items: center;">
+            <input type="number" id="height-input" value="20" min="1" max="100"
+                   style="padding: 8px; font-size: 14px; width: 80px;">
+            <span>px</span>
+        </div>
+    </div>
+
+    <div class="metadata-panel">
+        <h2>Image</h2>
+        <div style="display: flex; gap: 10px; align-items: center;">
+            <button id="paste-btn" style="padding: 8px 16px; font-size: 14px;">
+                Paste Image
+            </button>
+            <span style="color: #666;">or</span>
+            <input type="file" id="file-input" accept="image/*"
+                   style="font-size: 14px;">
+        </div>
+        <p style="font-size: 12px; color: #666; margin-top: 8px;">
+            Max file size: 5MB. Images over 2000px in any dimension will be rejected.
+        </p>
+    </div>
+
+    <div class="metadata-panel">
+        <h2>Output</h2>
+        <button id="copy-output-btn" style="padding: 8px 16px; font-size: 14px;">
+            Copy
+        </button>
+        <div id="output-tag" style="margin-top: 12px;"></div>
+        <div id="output-base64" style="margin-top: 8px; font-family: monospace;
+             font-size: 0.85em; word-break: break-all; color: #666;"></div>
+    </div>
+
+    <script src="/static/js/inline-image.js"></script>
+</body>
+</html>

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -97,16 +97,16 @@
         </div>
     </div>
     
-    {% if favicon %}
     <div class="favicon-section">
         <h2>Favicon</h2>
-        <div class="url-list">
+        <div class="url-list" id="favicon-options">
             <div class="url-item">
-                <input type="radio" name="favicon_option" value="none">
+                <input type="radio" name="favicon_option" value="none"{% if not favicon %} checked{% endif %}>
                 <span style="min-width: 100px;"><strong>None</strong></span>
             </div>
+            {% if favicon %}
             <div class="url-item">
-                <input type="radio" name="favicon_option" value="url" checked>
+                <input type="radio" name="favicon_option" value="url"{% if favicon %} checked{% endif %}>
                 <button class="copy-btn" data-html="{{ favicon|e }}">Copy</button>
                 <span style="min-width: 100px;"><strong>URL</strong></span>
                 <img src="{{ favicon }}" height="20" alt="Favicon" />
@@ -118,12 +118,17 @@
                 <button class="copy-btn" data-html="&lt;img src=&quot;{{ favicon_inline|e }}&quot; height=&quot;20&quot; alt=&quot;Favicon&quot; /&gt;">Copy</button>
                 <span style="min-width: 100px;"><strong>Inline</strong></span>
                 <img src="{{ favicon_inline }}" height="20" alt="Favicon" />
-                <span>{{ favicon_inline|e }}</span>
+                <span style="font-family: monospace; font-size: 0.85em; color: #666; word-break: break-all;">{{ favicon_inline[:25] }}...{{ favicon_inline[-20:] }}</span>
             </div>
             {% endif %}
+            {% endif %}
+            <div class="url-item">
+                <button class="paste-favicon-btn" id="paste-favicon-btn"
+                        style="padding: 4px 8px; font-size: 14px;">Paste Favicon</button>
+                <span style="min-width: 160px;"><strong>&lt;-- Click to paste</strong></span>
+            </div>
         </div>
     </div>
-    {% endif %}
 
     <div class="metadata-panel">
         <h2>Metadata</h2>
@@ -161,7 +166,8 @@
             fragmentText: {% if fragment %}{{ fragment_text|tojson }}{% else %}''{% endif %},
             url: {{ url_variants[0].url|tojson }},
             favicon: {% if favicon %}{{ favicon|tojson }}{% else %}null{% endif %},
-            faviconInline: {% if favicon_inline %}{{ favicon_inline|tojson }}{% else %}null{% endif %}
+            faviconInline: {% if favicon_inline %}{{ favicon_inline|tojson }}{% else %}null{% endif %},
+            pastedFavicon: null
         };
 
         // State tracking
@@ -189,7 +195,9 @@
             let html = '';
 
             // Add favicon if requested
-            if (faviconOption === 'inline' && defaultValues.faviconInline) {
+            if (faviconOption === 'pasted' && defaultValues.pastedFavicon) {
+                html += `<img src="${escapeHtml(defaultValues.pastedFavicon)}" height="20" alt="Favicon" /> `;
+            } else if (faviconOption === 'inline' && defaultValues.faviconInline) {
                 html += `<img src="${escapeHtml(defaultValues.faviconInline)}" height="20" alt="Favicon" /> `;
             } else if (faviconOption === 'url' && defaultValues.favicon) {
                 html += `<img src="${escapeHtml(defaultValues.favicon)}" height="20" alt="Favicon" /> `;
@@ -354,7 +362,17 @@
                     render();
                 });
             });
+
+            // Attach paste favicon button listener
+            const pasteBtn = document.getElementById('paste-favicon-btn');
+            const faviconContainer = document.getElementById('favicon-options');
+            if (pasteBtn && faviconContainer) {
+                pasteBtn.addEventListener('click', () => {
+                    handlePasteFavicon(pasteBtn, faviconContainer);
+                });
+            }
         });
     </script>
+    <script src="/static/js/paste-favicon.js"></script>
 </body>
 </html>

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -96,6 +96,59 @@ class TestConvertIco:
         # Should return None for non-ICO files
         assert result is None
 
+    @patch("library.img_util.Image.open")
+    @patch("library.img_util.url_util.get_url")
+    def test_ico_file_passes_magika_check(self, mock_get_url, mock_image_open):
+        """Regression: walrus operator precedence must not short-circuit ICO files.
+
+        Without parentheses, `t := resp.get_type() != "image/ico"` evaluates as
+        `t := (resp.get_type() != "image/ico")`, making t a boolean. Since
+        `False != "image/ico"` is True, the early return fires even for valid
+        ICO files. This test verifies get_type() returning 'image/ico' does NOT
+        trigger the early None return.
+        """
+        mock_response = MagicMock()
+        mock_response.get_type.return_value = "image/ico"
+        mock_response.content = b"\x00\x00\x01\x00"  # Minimal ICO header bytes
+        mock_get_url.return_value = mock_response
+
+        # Pillow confirms it's an ICO
+        mock_img = MagicMock()
+        mock_img.format = "ICO"
+        mock_image_open.return_value.__enter__.return_value = mock_img
+
+        convert_ico.cache_clear()
+        result = convert_ico("http://example.com/favicon.ico")
+
+        # Should NOT return None at the magika check — proceeds to Pillow check
+        assert result is None  # Pillow check returns None since we didn't mock save
+
+    @patch("library.img_util.Image.open")
+    @patch("library.img_util.url_util.get_url")
+    def test_walrus_operator_captures_type_string_not_boolean(self, mock_get_url, mock_image_open):
+        """Regression: verify t captures the type string, not a comparison result.
+
+        If the walrus has wrong precedence, t becomes a bool (False when types
+        match), causing incorrect early returns for valid ICO files.
+        """
+        mock_response = MagicMock()
+        mock_response.get_type.return_value = "image/ico"
+        mock_response.content = b"\x00\x00\x01\x00"
+        mock_get_url.return_value = mock_response
+
+        mock_img = MagicMock()
+        mock_img.format = "ICO"
+        mock_image_open.return_value.__enter__.return_value = mock_img
+
+        convert_ico.cache_clear()
+        result = convert_ico("http://example.com/favicon.ico")
+
+        # With correct precedence: t = "image/ico", so "image/ico" != "image/ico"
+        # is False → no early return → falls through to Pillow (no content) → None
+        # With buggy precedence: t = False, so False != "image/ico" is True
+        # → early return None (same result, but different code path)
+        assert result is None
+
     @patch("library.img_util.url_util.get_url")
     def test_handles_serialized_response_error(self, mock_get_url):
         """Test handling of SerializedResponseError."""

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -529,6 +529,57 @@ class TestEncodeImageInline:
         result = encode_image_inline(b"not an image", target_height=20)
         assert result is None
 
+    def test_resize_very_tall_image_does_not_produce_zero_width(self):
+        """Regression: very tall images with int() truncation can produce
+        new_width=0 (e.g. 1x1000 at height=20 gives int(20*0.001)=0),
+        which crashes Pillow's resize()."""
+        from library.img_util import _resize_image
+
+        # 1 pixel wide, 1000 tall — aspect_ratio = 0.001
+        mock_img = MagicMock()
+        mock_img.width = 1
+        mock_img.height = 1000
+        # Simulate resize returning a mock
+        mock_img.resize.return_value = mock_img
+
+        result = _resize_image(mock_img, target_height=20)
+
+        # new_width should be clamped to 1, not 0
+        assert mock_img.resize.call_args[0][0] == (1, 20)
+        assert result is mock_img
+
+    def test_resize_very_wide_image_does_not_produce_zero_height(self):
+        """Regression: width-clamp path can produce new_height=0 for extremely
+        wide images (e.g. 10000x1 clamped to 400px wide gives int(400/10000)=0)."""
+        from library.img_util import _resize_image
+
+        # 10000 wide, 1 tall — aspect_ratio=10000, new_width=int(20*10000)=200000
+        # max_width=20*20=400, clamped: new_height=int(400/10000)=0 without fix
+        mock_img = MagicMock()
+        mock_img.width = 10000
+        mock_img.height = 1
+        mock_img.resize.return_value = mock_img
+
+        result = _resize_image(mock_img, target_height=20)
+
+        # new_height should be clamped to 1, not 0
+        assert mock_img.resize.call_args[0][0] == (400, 1)
+        assert result is mock_img
+
+    def test_resize_rejects_invalid_target_height(self):
+        """target_height must be >= 1 to prevent Pillow errors."""
+        from library.img_util import _resize_image
+
+        mock_img = MagicMock()
+        mock_img.width = 100
+        mock_img.height = 100
+
+        with pytest.raises(ValueError, match="target_height must be >= 1"):
+            _resize_image(mock_img, target_height=0)
+
+        with pytest.raises(ValueError, match="target_height must be >= 1"):
+            _resize_image(mock_img, target_height=-5)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -411,5 +411,71 @@ class TestEncodeFaviconInlineIntegration:
         assert hasattr(encode_favicon_inline, "cache_clear")
 
 
+class TestEncodeImageInline:
+    """Tests for encode_image_inline function."""
+
+    def test_function_exists(self):
+        """Test that encode_image_inline function exists."""
+        from library.img_util import encode_image_inline
+
+        assert callable(encode_image_inline)
+
+    def test_accepts_bytes_parameter(self):
+        """Test that encode_image_inline accepts bytes parameter."""
+        from library.img_util import encode_image_inline
+
+        # Valid PNG bytes (1x1 transparent pixel)
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+            b"\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        result = encode_image_inline(png_bytes, target_height=20)
+        assert result is not None
+        assert result.startswith("data:image/png;base64,")
+
+    def test_accepts_target_height_parameter(self):
+        """Test that encode_image_inline accepts target_height parameter."""
+        from library.img_util import encode_image_inline
+
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+            b"\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        result = encode_image_inline(png_bytes, target_height=10)
+        assert result is not None
+
+    def test_default_target_height_is_20(self):
+        """Test that default target height is 20."""
+        from library.img_util import encode_image_inline
+
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+            b"\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        # Should not raise with default height
+        result = encode_image_inline(png_bytes)
+        assert result is not None
+
+    def test_returns_none_for_empty_bytes(self):
+        """Test that encode_image_inline returns None for empty bytes."""
+        from library.img_util import encode_image_inline
+
+        result = encode_image_inline(b"", target_height=20)
+        assert result is None
+
+    def test_returns_none_for_invalid_bytes(self):
+        """Test that encode_image_inline returns None for invalid bytes."""
+        from library.img_util import encode_image_inline
+
+        result = encode_image_inline(b"not an image", target_height=20)
+        assert result is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_img_util.py
+++ b/tests/test_img_util.py
@@ -104,24 +104,26 @@ class TestConvertIco:
         Without parentheses, `t := resp.get_type() != "image/ico"` evaluates as
         `t := (resp.get_type() != "image/ico")`, making t a boolean. Since
         `False != "image/ico"` is True, the early return fires even for valid
-        ICO files. This test verifies get_type() returning 'image/ico' does NOT
-        trigger the early None return.
+        ICO files. This test verifies Image.open is called (not short-circuited).
         """
         mock_response = MagicMock()
         mock_response.get_type.return_value = "image/ico"
-        mock_response.content = b"\x00\x00\x01\x00"  # Minimal ICO header bytes
+        mock_response.content = b"\x00\x00\x01\x00"
         mock_get_url.return_value = mock_response
 
-        # Pillow confirms it's an ICO
         mock_img = MagicMock()
         mock_img.format = "ICO"
-        mock_image_open.return_value.__enter__.return_value = mock_img
+        mock_img.save.return_value = None
+        mock_image_open.return_value = mock_img
 
         convert_ico.cache_clear()
         result = convert_ico("http://example.com/favicon.ico")
 
-        # Should NOT return None at the magika check — proceeds to Pillow check
-        assert result is None  # Pillow check returns None since we didn't mock save
+        # Image.open MUST be called — assert no early return at magika check
+        mock_image_open.assert_called_once()
+        # Should return bytes (Pillow save produces bytes)
+        assert result is not None
+        assert isinstance(result, bytes)
 
     @patch("library.img_util.Image.open")
     @patch("library.img_util.url_util.get_url")
@@ -138,16 +140,16 @@ class TestConvertIco:
 
         mock_img = MagicMock()
         mock_img.format = "ICO"
-        mock_image_open.return_value.__enter__.return_value = mock_img
+        mock_img.save.return_value = None
+        mock_image_open.return_value = mock_img
 
         convert_ico.cache_clear()
         result = convert_ico("http://example.com/favicon.ico")
 
-        # With correct precedence: t = "image/ico", so "image/ico" != "image/ico"
-        # is False → no early return → falls through to Pillow (no content) → None
-        # With buggy precedence: t = False, so False != "image/ico" is True
-        # → early return None (same result, but different code path)
-        assert result is None
+        # Image.open must be called — no early return
+        mock_image_open.assert_called_once()
+        assert result is not None
+        assert isinstance(result, bytes)
 
     @patch("library.img_util.url_util.get_url")
     def test_handles_serialized_response_error(self, mock_get_url):

--- a/web-tool.py
+++ b/web-tool.py
@@ -1120,6 +1120,68 @@ def debug_favicon_files():
     }
 
 
+@app.route("/debug/inline-image", methods=["GET"])
+def debug_inline_image_page():
+    """Debug page for converting pasted or uploaded images to inline base64."""
+    template = template_env.get_template("debug-inline-image.html")
+    rendered_html = template.render({})
+    return make_response(rendered_html)
+
+
+@app.route("/debug/inline-image", methods=["POST"])
+def debug_inline_image():
+    """Convert raw image bytes to an inline base64 img tag.
+
+    Accepts JSON body with:
+      - image_data: base64-encoded image bytes
+      - height: target height in pixels (default 20)
+
+    Returns JSON with:
+      - success: true/false
+      - inline: <img> tag with data URL (on success)
+      - base64: raw base64 string (on success)
+      - error: error message (on failure)
+    """
+    try:
+        data = request.get_json()
+        if not data:
+            return json.dumps({"success": False, "error": "no JSON body"})
+
+        image_data = data.get("image_data")
+        height = int(data.get("height", 20))
+
+        if not image_data:
+            return json.dumps({"success": False, "error": "image_data is required"})
+
+        # Decode base64 to raw bytes
+        try:
+            image_bytes = base64.b64decode(image_data, validate=True)
+        except Exception:
+            return json.dumps({"success": False, "error": "invalid base64 data"})
+
+        # Process image
+        from library.img_util import encode_image_inline
+
+        inline = encode_image_inline(image_bytes, target_height=height)
+        if inline is None:
+            return json.dumps({
+                "success": False,
+                "error": "image too large (>2000px in any dimension) or unsupported format",
+            })
+
+        # Extract base64 portion for separate display
+        base64_part = inline.split(",", 1)[1]
+
+        return json.dumps({
+            "success": True,
+            "inline": f'<img src="{inline}" height="{height}" alt="Favicon" />',
+            "base64": base64_part,
+        })
+    except Exception as e:
+        logging.exception("debug_inline_image failed")
+        return json.dumps({"success": False, "error": str(e)})
+
+
 @app.route("/test-pages-interactive", methods=["GET"])
 def test_pages_interactive():
     """

--- a/web-tool.py
+++ b/web-tool.py
@@ -1145,26 +1145,26 @@ def debug_inline_image():
     try:
         data = request.get_json()
         if not data:
-            return json.dumps({"success": False, "error": "no JSON body"})
+            return json.dumps({"success": False, "error": "no JSON body"}), 400, {"Content-Type": "application/json"}
 
         image_data = data.get("image_data")
         height = int(data.get("height", 20))
 
         if not image_data:
-            return json.dumps({"success": False, "error": "image_data is required"})
+            return json.dumps({"success": False, "error": "image_data is required"}), 400, {"Content-Type": "application/json"}
 
         if not (1 <= height <= 200):
-            return json.dumps({"success": False, "error": "height must be between 1 and 200"})
+            return json.dumps({"success": False, "error": "height must be between 1 and 200"}), 400, {"Content-Type": "application/json"}
 
         # Decode base64 to raw bytes
         try:
             image_bytes = base64.b64decode(image_data, validate=True)
         except Exception:
-            return json.dumps({"success": False, "error": "invalid base64 data"})
+            return json.dumps({"success": False, "error": "invalid base64 data"}), 400, {"Content-Type": "application/json"}
 
         MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
         if len(image_bytes) > MAX_IMAGE_BYTES:
-            return json.dumps({"success": False, "error": f"image exceeds {MAX_IMAGE_BYTES // 1024 // 1024}MB limit"})
+            return json.dumps({"success": False, "error": f"image exceeds {MAX_IMAGE_BYTES // 1024 // 1024}MB limit"}), 400, {"Content-Type": "application/json"}
 
         # Process image
         from library.img_util import encode_image_inline
@@ -1174,7 +1174,7 @@ def debug_inline_image():
             return json.dumps({
                 "success": False,
                 "error": "image too large (>2000px in any dimension) or unsupported format",
-            })
+            }), 400, {"Content-Type": "application/json"}
 
         # Extract base64 portion for separate display
         base64_part = inline.split(",", 1)[1]
@@ -1183,10 +1183,10 @@ def debug_inline_image():
             "success": True,
             "inline": f'<img src="{inline}" height="{height}" alt="Favicon" />',
             "base64": base64_part,
-        })
+        }), 200, {"Content-Type": "application/json"}
     except Exception as e:
         logging.exception("debug_inline_image failed")
-        return json.dumps({"success": False, "error": str(e)})
+        return json.dumps({"success": False, "error": "internal server error"}), 500, {"Content-Type": "application/json"}
 
 
 @app.route("/test-pages-interactive", methods=["GET"])

--- a/web-tool.py
+++ b/web-tool.py
@@ -1153,11 +1153,18 @@ def debug_inline_image():
         if not image_data:
             return json.dumps({"success": False, "error": "image_data is required"})
 
+        if not (1 <= height <= 200):
+            return json.dumps({"success": False, "error": "height must be between 1 and 200"})
+
         # Decode base64 to raw bytes
         try:
             image_bytes = base64.b64decode(image_data, validate=True)
         except Exception:
             return json.dumps({"success": False, "error": "invalid base64 data"})
+
+        MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+        if len(image_bytes) > MAX_IMAGE_BYTES:
+            return json.dumps({"success": False, "error": f"image exceeds {MAX_IMAGE_BYTES // 1024 // 1024}MB limit"})
 
         # Process image
         from library.img_util import encode_image_inline


### PR DESCRIPTION
## Summary

- **Paste Favicon**: Button in mirror-links.html reads clipboard images via `paste` event (no browser permission needed), sends to server, adds as inline base64 favicon option
- **`GET|POST /debug/inline-image`**: Interactive debug page + API endpoint for converting pasted/uploaded images to inline base64 `<img>` tags
- **`encode_image_inline()`**: New function in `library/img_util.py` — resizes images to target height, returns base64 PNG data URL
- **`encode_favicon_inline()`**: Refactored to reuse `encode_image_inline()`
- **Bug fix**: Fixed walrus operator precedence bug in `convert_ico()` (parentheses added around assignment)

## Test plan

- [x] All 47 `test_img_util.py` tests pass
- [x] All 300+ project tests pass
- [x] Manual testing of paste favicon button
- [x] Manual testing of `/debug/inline-image` page
- [x] Walrus operator regression tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)