### PR TITLE
docs: clarify test and lint commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Stop container**: `make docker-stop`
 
 ### Git Workflow
-- **Delete merged branch**: `git branch -D <branch>` (use -D not -d if merged via PR)
+- **Delete merged branch**: `git branch -d <branch>` (safe delete; use `-D` to force delete unmerged)
 
 ## Architecture & Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Development dependencies**: `make dev`
 
 ### Quality & Testing
-- **Lint code**: `make lint` (uses ruff)
+- **Lint code**: `make lint` (requires `make dev` first to install ruff)
 - **Format code**: `make format` (uses ruff)
 - **All quality checks**: `make check` (lint + format + import sorting)
 - **Run all tests**: `make test` (via `uv run pytest`)
@@ -18,11 +18,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run tests with verbose output**: `make testv`
 - **Run a specific test file**: `uv run pytest tests/test_filename.py -v`
 - **Run a specific test class**: `uv run pytest tests/test_filename.py::TestClassName -v`
+- **Run tests**: `uv run pytest tests/` (requires `make dev` first to install test deps)
 
 ### Docker
 - **Run published image**: `make docker-run`
 - **Build image**: `make docker-build`
 - **Stop container**: `make docker-stop`
+
+### Git Workflow
+- **Delete merged branch**: `git branch -D <branch>` (use -D not -d if merged via PR)
 
 ## Architecture & Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Development dependencies**: `make dev`
 
 ### Quality & Testing
-- **Lint code**: `make lint` (requires `make dev` first to install ruff)
-- **Format code**: `make format` (uses ruff)
+- **Prerequisite**: Run `make dev` first to install lint/format/test tools (ruff, pytest)
+- **Lint code**: `make lint`
+- **Format code**: `make format`
 - **All quality checks**: `make check` (lint + format + import sorting)
-- **Run all tests**: `make test` (via `uv run pytest`)
+- **Run all tests**: `make test`
 - **Run tests with coverage**: `make testcov`
 - **Run tests with verbose output**: `make testv`
 - **Run a specific test file**: `uv run pytest tests/test_filename.py -v`
 - **Run a specific test class**: `uv run pytest tests/test_filename.py::TestClassName -v`
-- **Run tests**: `uv run pytest tests/` (requires `make dev` first to install test deps)
 
 ### Docker
 - **Run published image**: `make docker-run`


### PR DESCRIPTION
## Summary
- Consolidate `make dev` prerequisite into a single note at the top of Quality & Testing section
- Remove redundant parentheticals from individual commands
- Fix `git branch -d/-D` explanation (was previously backwards)

Previously: multiple commands showed individual "requires make dev" notes; now a single prerequisite line at the top covers all.

## Test Plan
- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)