### PR TITLE
fix: replace undefined faviconW with favW in buildHtmlLink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ uv.lock
 
 # Local dev artifacts
 .mcp.json
+.playwright-mcp/
 .superpowers/
 
 # Node (not used by this Python project but sometimes present)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Delete merged branch**: `git branch -d <branch>` (safe delete; use `-D` to force delete unmerged)
 
 ## Python Runtime
-- **Use `uv run`** for all commands — `pyproject.toml` requires Python 3.13. Using a pyenv-managed Python will fail to find test dependencies.
+- **Use `uv run`** for all commands — `pyproject.toml` requires Python 3.13 only (`>=3.13,<3.14`). Using a pyenv-managed Python will fail to find test dependencies.
 - **Dev deps required:** Run `make dev` before `make test` or `uv run python -m pytest` — pytest/ruff are dev dependencies, not installed by `make install`
 
 ## Module Packaging
@@ -64,15 +64,15 @@ The `web-tool` is a utility for extracting and processing information from web p
 3. **Processing**: The `library/` directory contains the core logic for HTML parsing, text extraction, and favicon management.
 
 ### Key Components
-- **Core Application**: `web-tool.py` - The main entry point and Flask server.
-- **Logic Library**: `library/` — `util.py` (PageMetadata, MirrorData, TitleVariants, ClipCache), `html_util.py` (favicon system, link parsing), `text_util.py` (NLP extraction), `url_util.py` (URL parsing, fetching), `img_util.py` (ICO/SVG conversion), `unicode_util.py` (category names), `docker_util.py` (container detection)
+- **Core Application**: `web-tool.py` - The main entry point and Flask server. Registers blueprints from `routes/` (`mirror_links`, `mirror_favicons`, `javascript`, `debug`).
+- **Logic Library**: `library/` — `util.py` (PageMetadata, MirrorData, TitleVariants, ClipCache), `html_util.py` (favicon system, link parsing), `text_util.py` (NLP extraction), `text_format.py` (ascii_text, html_text, path_safe_filename), `title_variants.py` (deduplicate_variants), `url_util.py` (URL parsing, fetching), `img_util.py` (ICO/SVG conversion), `unicode_util.py` (category names), `content_type.py` (MIME type detection), `fragment_handlers.py` (anchor/heading fragment resolution), `docker_util.py` (container detection)
 - **Favicon System**: Implements a three-tier cache for favicons:
     1. `static/favicon-overrides.yml` (User Overrides - Highest priority)
     2. `static/favicon.yml` (App Defaults - Medium priority)
     3. `local-cache/favicon.yml` or `/data/favicon.yml` (Auto-discovered - Lowest priority)
 - **Static Assets**: `static/` contains CSS and favicon YAML configs. Bookmarklet JS is served dynamically via `/js/<name>.js` from `mirror.js` in templates; only `inline-image.js` and `paste-favicon.js` live in `static/js/`.
 - **Templates**: `templates/` — key templates: `mirror-links.html` (link generation), `mirror-favicons.html` (favicon management), `plain_text.html` (auto-copy wrapper), `clip-proxy.html` (container clipboard bridge)
-- **Specs**: `specs/` contains 18 page specs and a parent spec. See `specs/web-tool-spec.md` for the full index.
+- **Specs**: `specs/` contains 17 page specs and a parent spec. See `specs/web-tool-spec.md` for the full index.
 
 ### Specs Conventions
 - Each web-tool page has a spec at `specs/pages/<name>.md` following the `mirror-links.md` format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Doc sync:** When adding/removing test files or test classes, update `TESTING.md` and `TEST_COVERAGE.md` in the same commit or a follow-up — update both test count totals and list new classes
 - **Unused variables:** Run `ruff check --select F841` before committing; unused assignments in tests often indicate incomplete assertions
 - **Test pattern consistency:** When adding paired tests (e.g., ICO/SVG variants), match the existing test's structure exactly — don't assign `result` if sibling test doesn't use it
-- **Test count tracking:** Total test count is tracked in `TEST_COVERAGE.md` — update when adding tests (current: 323)
+- **Test count tracking:** Total test count is tracked in `TEST_COVERAGE.md` — update when adding tests (current: 328)
+- **JS template testing:** Template rendering tests (`test_js_escaping.py`) verify JS variable names and structure in rendered output, but cannot catch runtime ReferenceErrors — use Playwright/browser testing for JS runtime bugs
 
 ## Workflow
 - **Multi-step implementations:** Use `superpowers:subagent-driven-development` skill. Create tasks with `TaskCreate`, set dependencies, dispatch one `general-purpose` subagent per task.

--- a/TESTING.md
+++ b/TESTING.md
@@ -202,6 +202,13 @@ Tests for JavaScript string escaping in `mirror-links.html` template:
 - Null favicon renders as `null` in JavaScript
 - Favicon URL renders as JavaScript string
 
+#### `TestBuildHtmlLinkTemplate` (4 tests)
+Regression tests for `buildHtmlLink` JS variable references in `mirror-links.html`:
+- `buildHtmlLink` uses `favW` (local const) in width attributes, not `faviconW` (undefined)
+- `buildHtmlLink` uses `favH` (local const) in height attributes, not `faviconHeight` (parameter)
+- Local constants `favH` and `favW` are defined before favicon branches
+- No undefined variable references (`faviconW`) appear in the function body
+
 #### `TestEscapeMarkdownText` (9 tests)
 Tests for `escapeMarkdownText()` function in `mirror-links.html` template:
 - Plain text passes through unchanged
@@ -263,11 +270,12 @@ Tests URL variant generation:
 - Root variant returns scheme://netloc/first-path-segment
 - Host variant returns scheme://netloc only
 
-#### `TestMirrorLinksEndpoint` (3 integration tests)
+#### `TestMirrorLinksEndpoint` (4 integration tests)
 Tests the `/mirror-links` endpoint:
 - Accepts batchId parameter for clipboard data
 - Returns HTML containing the page title
 - Handles emoji in page content
+- Verifies `buildHtmlLink` uses `favW` (not undefined `faviconW`) in rendered JS
 
 #### `TestTestPageEndpoint` (7 integration tests)
 Tests the `/test-page` endpoint:
@@ -462,12 +470,13 @@ uv run pytest tests/
 | `TestNormalizeNetloc` | test_url_util.py | 3 | Netloc normalization |
 | `TestGetFirstPathSegment` | test_url_util.py | 4 | Path segment extraction |
 | `TestMirrorLinksJsEscaping` | test_js_escaping.py | 7 | JavaScript string escaping |
+| `TestBuildHtmlLinkTemplate` | test_js_escaping.py | 4 | buildHtmlLink JS variable references |
 | `TestEscapeMarkdownText` | test_markdown_escaping.py | 9 | Markdown text escaping |
 | `TestMarkdownUrlWrapping` | test_markdown_escaping.py | 9 | Markdown URL wrapping |
 | `TestBuildMarkdownLink` | test_markdown_escaping.py | 8 | Markdown link construction |
 | `TestRealWorldExamples` | test_markdown_escaping.py | 4 | Real-world escaping scenarios |
 
-**Total: 323 tests across 14 test modules**
+**Total: 328 tests across 14 test modules**
 
 ## Continuous Integration
 

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -21,13 +21,13 @@ tests/
 ├── test_img_util.py             # Image conversion tests (~55 tests)
 ├── test_favicon_validation.py   # Favicon validation tests (~9 tests)
 ├── test_fragment_variants.py    # Fragment variant duplicate detection (~8 tests)
-├── test_integration_pages.py    # Integration tests (~20 tests)
-├── test_js_escaping.py          # JavaScript escaping tests (~9 tests)
+├── test_integration_pages.py    # Integration tests (~21 tests)
+├── test_js_escaping.py          # JavaScript escaping tests (~13 tests)
 ├── test_markdown_escaping.py    # Markdown link escaping tests (~31 tests)
 └── test_url_decoding.py         # URL decoding tests (~6 tests)
 ```
 
-**Total: 323 test cases across 14 test modules**
+**Total: 328 test cases across 14 test modules**
 
 ## Module-by-Module Coverage
 
@@ -201,14 +201,14 @@ tests/
 - All three options present with correct values
 - Pydantic-style fragment fallback
 
-### 10. `test_integration_pages.py` (~20 tests)
+### 10. `test_integration_pages.py` (~21 tests)
 **Purpose:** Integration tests for URL/fragment/title handling via Flask test client
 
 **Test Classes:**
 - `TestFragmentResolution` (4 tests) - Fragment text resolution
 - `TestTitleVariants` (3 tests) - Title variant generation
 - `TestURLVariants` (3 tests) - URL variant generation
-- `TestMirrorLinksEndpoint` (3 tests) - /mirror-links endpoint
+- `TestMirrorLinksEndpoint` (4 tests) - /mirror-links endpoint
 - `TestTestPageEndpoint` (7 tests) - /test-page endpoint
 
 **Coverage:**
@@ -216,12 +216,14 @@ tests/
 - Title and URL variant generation
 - Emoji in page content
 - Batch ID parameter handling
+- buildHtmlLink uses favW (not undefined faviconW) in rendered JS
 
-### 11. `test_js_escaping.py` (~9 tests)
-**Purpose:** Test JavaScript string escaping in mirror-links template
+### 11. `test_js_escaping.py` (~13 tests)
+**Purpose:** Test JavaScript string escaping and variable references in mirror-links template
 
 **Test Classes:**
 - `TestMirrorLinksJsEscaping` (7 tests) - JS string escaping via tojson filter
+- `TestBuildHtmlLinkTemplate` (4 tests) - buildHtmlLink JS variable references
 - Additional tests for markdown escape template logic
 
 **Coverage:**
@@ -229,6 +231,9 @@ tests/
 - Title with Unicode characters
 - Null favicon handling
 - Markdown link template URL wrapping logic
+- buildHtmlLink uses favW/favH local consts (not undefined faviconW/faviconHeight)
+- Local constant definitions present before favicon branches
+- No undefined variable references in buildHtmlLink function body
 
 ### 12. `test_markdown_escaping.py` (~31 tests)
 **Purpose:** Test Markdown link escaping (escapeMarkdownText, buildMarkdownLink)

--- a/docs/superpowers/specs/2026-04-17-faviconW-reference-error-design.md
+++ b/docs/superpowers/specs/2026-04-17-faviconW-reference-error-design.md
@@ -1,0 +1,68 @@
+# Fix: `faviconW` ReferenceError in `buildHtmlLink`
+
+**Date:** 2026-04-17
+**Status:** Proposed
+
+## Problem
+
+When the mirror-links page renders for any URL that has a favicon, all four link
+format displays (HTML, Markdown, Wiki-link, Simple) appear empty. The browser
+console shows:
+
+```
+ReferenceError: faviconW is not defined
+    at buildHtmlLink (mirror-links:256:100)
+    at render (mirror-links:306:30)
+    at HTMLDocument.<anonymous> (mirror-links:387:13)
+```
+
+## Root Cause
+
+In `templates/mirror-links.html`, the `buildHtmlLink` function defines local
+constants for fallback dimensions:
+
+```javascript
+const favH = faviconHeight || 20;   // line 202
+const favW = faviconWidth || 20;     // line 203
+```
+
+Lines 205, 207, and 209 reference `faviconW` (capital W after "favicon")
+instead of the local const `favW`. Since `faviconW` is not declared in the
+function scope, JavaScript throws a `ReferenceError`.
+
+The `height` attributes on those same lines correctly use `favH`; only the
+`width` attributes use the wrong identifier.
+
+**Affected lines:**
+
+| Line | Current (broken) | Intended |
+|------|-------------------|----------|
+| 205  | `width="${faviconW}"` | `width="${favW}"` |
+| 207  | `width="${faviconW}"` | `width="${favW}"` |
+| 209  | `width="${faviconW}"` | `width="${favW}"` |
+
+## Impact
+
+- Any page with a favicon triggers the error on initial render because the
+  default favicon option is "url"
+- Pages without favicons are unaffected (the favicon branches are skipped)
+- The error prevents all four link formats from rendering, not just HTML
+
+## Fix
+
+Replace `faviconW` with `favW` on lines 205, 207, and 209 of
+`templates/mirror-links.html`. Three character-for-character substitutions.
+
+No other changes:
+- The existing `favH` references are correct
+- No test changes needed (Python test suite doesn't cover client-side JS)
+- The CLAUDE.md "Known Bug Patterns" entry for `buildHtmlLink` is accurate
+  documentation of this pattern and should remain
+
+## Verification
+
+After applying the fix, navigate to `mirror-links` for a URL with a favicon
+(e.g., ibm.com). Confirm:
+1. No `ReferenceError` in the browser console
+2. All four link format rows display content
+3. Favicon image appears with correct dimensions (width ≈ height ≈ 20px)

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -202,11 +202,11 @@
             const favH = faviconHeight || 20;
             const favW = faviconWidth || 20;
             if (faviconOption === 'pasted' && defaultValues.pastedFavicon) {
-                html += `<img src="${escapeHtml(defaultValues.pastedFavicon)}" height="${favH}" width="${faviconW}" alt="Favicon" /> `;
+                html += `<img src="${escapeHtml(defaultValues.pastedFavicon)}" height="${favH}" width="${favW}" alt="Favicon" /> `;
             } else if (faviconOption === 'inline' && defaultValues.faviconInline) {
-                html += `<img src="${escapeHtml(defaultValues.faviconInline)}" height="${favH}" width="${faviconW}" alt="Favicon" /> `;
+                html += `<img src="${escapeHtml(defaultValues.faviconInline)}" height="${favH}" width="${favW}" alt="Favicon" /> `;
             } else if (faviconOption === 'url' && defaultValues.favicon) {
-                html += `<img src="${escapeHtml(defaultValues.favicon)}" height="${favH}" width="${faviconW}" alt="Favicon" /> `;
+                html += `<img src="${escapeHtml(defaultValues.favicon)}" height="${favH}" width="${favW}" alt="Favicon" /> `;
             }
 
             // Add link with appropriate text

--- a/tests/test_integration_pages.py
+++ b/tests/test_integration_pages.py
@@ -260,6 +260,32 @@ class TestMirrorLinksEndpoint:
         result_html = resp.get_data(as_text=True)
         assert "Emoji Test" in result_html
 
+    def test_mirror_links_with_favicon_renders_js_correctly(self, app_client):
+        """buildHtmlLink uses favW (defined const), not faviconW (undefined).
+
+        Regression test: a typo caused buildHtmlLink to reference the
+        undefined variable faviconW instead of the local const favW,
+        crashing render() on every page with a favicon.
+        """
+        url = "http://localhost/test"
+        html = (
+            "<html><head><title>Fav Test</title>"
+            '<link rel="icon" href="/favicon.png">'
+            "</head><body><h1>Fav Test</h1></body></html>"
+        )
+        batch_id, text_len = _submit_clipboard(
+            app_client, url, "Fav Test", html, "550e8400-e29b-41d4-a716-446655440009"
+        )
+
+        resp = _get_mirror_links(app_client, url, batch_id, text_len)
+        assert resp.status_code == 200
+        result_html = resp.get_data(as_text=True)
+
+        # The rendered JS must use favW in img width attributes
+        assert 'width="${favW}"' in result_html
+        # Must NOT use the undefined variable faviconW in template literals
+        assert 'width="${faviconW}"' not in result_html
+
 
 @pytest.mark.integration
 class TestTestPageEndpoint:

--- a/tests/test_js_escaping.py
+++ b/tests/test_js_escaping.py
@@ -191,5 +191,87 @@ class TestMirrorLinksJsEscaping:
         assert "encodeURIComponent" in rendered
 
 
+class TestBuildHtmlLinkTemplate:
+    """Regression tests for buildHtmlLink JS variable references.
+
+    The buildHtmlLink function defines local const aliases:
+        const favH = faviconHeight || 20;
+        const favW = faviconWidth || 20;
+    The favicon <img> tags must use favW/favH (the aliases), not the
+    raw parameter names faviconWidth/faviconHeight. A prior bug used
+    the undefined variable faviconW, which threw a ReferenceError that
+    crashed render() on every page with a favicon.
+    """
+
+    @pytest.fixture
+    def template_env(self):
+        """Create Jinja2 environment for testing templates."""
+        template_dir = Path(__file__).parent.parent / "templates"
+        env = Environment(loader=FileSystemLoader(template_dir))
+        return env
+
+    def _render_with_favicon(self, template_env):
+        """Render mirror-links.html with a favicon URL."""
+        template = template_env.get_template("mirror-links.html")
+        return template.render(
+            title="Test",
+            title_variants=[{"value": "Test", "label": "Original"}],
+            fragment="",
+            fragment_text="",
+            url_variants=[{"url": "https://example.com", "label": "Original"}],
+            favicon="https://example.com/favicon.png",
+            favicon_inline=None,
+        )
+
+    def test_buildHtmlLink_uses_favW_not_faviconW(self, template_env):
+        """buildHtmlLink must use favW (local const), not faviconW (undefined)."""
+        rendered = self._render_with_favicon(template_env)
+
+        # All three favicon branches (pasted, inline, url) must use favW
+        assert 'width="${favW}"' in rendered
+        # faviconW must not appear inside template literals — only as
+        # the function parameter name and in the const definition
+        assert 'width="${faviconW}"' not in rendered
+
+    def test_buildHtmlLink_uses_favH_not_faviconHeight(self, template_env):
+        """buildHtmlLink must use favH (local const) in height attributes."""
+        rendered = self._render_with_favicon(template_env)
+
+        assert 'height="${favH}"' in rendered
+        # faviconHeight should only appear as parameter name and const def,
+        # not inside the img tag template literals
+        assert 'height="${faviconHeight}"' not in rendered
+
+    def test_buildHtmlLink_constants_defined(self, template_env):
+        """buildHtmlLink must define favH and favW before the favicon branches."""
+        rendered = self._render_with_favicon(template_env)
+
+        assert "const favH = faviconHeight || 20;" in rendered
+        assert "const favW = faviconWidth || 20;" in rendered
+
+    def test_no_undefined_js_references_in_buildHtmlLink(self, template_env):
+        """buildHtmlLink must not reference undefined variables.
+
+        After the function parameter list, any reference to faviconW
+        (capital W after 'favicon') would be an undefined variable.
+        The parameter name is faviconWidth (lowercase w after 'icon').
+        Use regex to match faviconW as a standalone token, not as a
+        substring of the valid parameter name faviconWidth.
+        """
+        import re
+
+        rendered = self._render_with_favicon(template_env)
+
+        # Extract the buildHtmlLink function body
+        func_start = rendered.index("function buildHtmlLink(")
+        func_end = rendered.index("}", rendered.index("// Add link with appropriate text", func_start))
+        func_body = rendered[func_start:func_end]
+
+        # faviconW must not appear as a standalone token (not part of faviconWidth)
+        # Match faviconW that is NOT followed by 'idth' (which would make it faviconWidth)
+        bad_refs = re.findall(r"faviconW(?!idth)", func_body)
+        assert bad_refs == [], f"Found undefined variable references: {bad_refs}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fixed a `ReferenceError: faviconW is not defined` in the `buildHtmlLink` function of `mirror-links.html` that crashed `render()` and left all four link formats (HTML, Markdown, Wiki-link, Simple) empty on any page with a favicon
- The `width` attributes on lines 205, 207, 209 referenced `faviconW` (undeclared) instead of `favW` (the local const alias defined on line 203), while the corresponding `height` attributes correctly used `favH`
- Verified with Playwright: zero console errors, all link formats render correctly for ibm.com and other sites with favicons

## Test plan

- [x] Navigated to `/mirror-links` for ibm.com (has favicon) — confirmed all 4 link formats render
- [x] Switched favicon option to "Inline" — confirmed no errors
- [x] Verified no `ReferenceError` in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)