### PR TITLE
fix: three mirror-links UI bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Stop container**: `make docker-stop`
 
 ### Git Workflow
+
+#### Branch Verification Check
+- **Always verify branch before committing** — run `git branch --show-current` after subagent work completes
+- **Subagents may not respect branch rules** — the parent session must enforce branch discipline
+- **If on main/master/develop/trunk after subagent work**: stop and create feature branch before proceeding
+
 - **Delete merged branch**: `git branch -d <branch>` (safe delete; use `-D` to force delete unmerged)
 - **Feature branches**: Never commit directly to `main`/`master` — always create feature branch first
 - **Style hygiene**: Move inline styles to CSS classes; use existing design tokens before creating new ones
+- **Worktrees:** Use `git worktree add .worktrees/<branch> -b <branch>` for isolated feature work. Always run `make dev` and `make test` in the worktree before dispatching subagents
 
 ## Python Runtime
 - **Use `uv run`** for all commands — `pyproject.toml` requires Python 3.14 only (`>=3.14,<3.15`). Using a pyenv-managed Python will fail to find test dependencies.
@@ -49,8 +56,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## CSS Design System
 - **Tokens:** Use CSS custom properties (`--color-*`, `--space-*`, `--font-size-*`) from `static/mirror.css`
+- **Fluid widths:** Use `width: clamp(min, preferred%, max)` instead of media queries for responsive containers
 - **Components:** Prefer semantic classes (`.panel`, `.variant-row`, `.btn-copy`) over inline styles
 - **Tooltip positioning:** Add `window.scrollX/Y` to `getBoundingClientRect()` coords for accurate placement
+- **Long metadata strings:** Add `word-wrap: break-word` to any text container that may hold long unbreakable strings (cookie strings, base64, URLs)
 
 ## Shared JavaScript
 - **tooltip.js:** Shared `showTooltip()` and `attachCopyListeners()` functions — import in templates with `<script src="/static/js/tooltip.js">`
@@ -109,6 +118,7 @@ The `web-tool` is a utility for extracting and processing information from web p
 - `buildHtmlLink` uses `favH`/`favW` (the local const aliases, not the outer parameter names)
 - Template domain extraction must use backend-computed `override_domain`/`override_path_scope` — string-splitting on `/` reverses the TLD
 - Walrus operator precedence: `(t := resp.get_type()) != "image/svg"` — parentheses required around walrus assignment before comparison
+- **Dynamic radio buttons:** `querySelectorAll` at `DOMContentLoaded` misses elements added later. Use event delegation on a parent container that exists at load time (e.g., `#favicon-options`) for dynamically added radio/checkbox groups
 
 ### Technical Stack
 - **Backend**: Python 3.14, Flask

--- a/docs/superpowers/plans/2026-04-18-mirror-links-bugfixes.md
+++ b/docs/superpowers/plans/2026-04-18-mirror-links-bugfixes.md
@@ -1,0 +1,178 @@
+# Mirror Links Bug Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 3 UI bugs on the Mirror Links page: cookie string wrapping, pasted favicon re-selection via radio buttons, and redundant previews for non-HTML link formats.
+
+**Architecture:** Two-file change — `static/mirror.css` (CSS fixes) and `templates/mirror-links.html` (JS event delegation). All changes are isolated and minimal.
+
+**Tech Stack:** Vanilla CSS, vanilla JavaScript (no framework).
+
+---
+
+## Files Modified
+
+| File | Responsibility |
+|------|---------------|
+| `static/mirror.css` | Add `word-wrap` to `.metadata-item`; add `:nth-child` rule to hide non-HTML previews |
+| `templates/mirror-links.html` | Replace `querySelectorAll` radio loop with event delegation on `#favicon-options` |
+
+---
+
+## Task 1: Cookie String Wrapping
+
+**Files:**
+- Modify: `static/mirror.css:348-355`
+
+- [ ] **Step 1: Read the current `.metadata-item` rule**
+
+Locate lines 348-355 in `static/mirror.css`.
+
+- [ ] **Step 2: Add `word-wrap: break-word` and `overflow-wrap: break-word`**
+
+Replace the current rule with:
+
+```css
+.metadata-item {
+    margin-bottom: var(--space-sm);
+    font-size: var(--font-size-sm);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.metadata-item strong {
+    color: var(--color-text);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add static/mirror.css
+git commit -m "fix: enable word-wrap for metadata-item strings"
+```
+
+---
+
+## Task 2: Pasted Favicon Radio Event Delegation
+
+**Files:**
+- Modify: `templates/mirror-links.html:340-354`
+
+- [ ] **Step 1: Read the radio change listener block (lines 340-354)**
+
+The current code loops over all radios with `querySelectorAll` at `DOMContentLoaded` time.
+
+- [ ] **Step 2: Replace the radio/checkbox listener with event delegation**
+
+Remove the `querySelectorAll` loop for favicon_option. Instead, add a delegated listener on `#favicon-options` inside the `DOMContentLoaded` handler.
+
+Find the existing listener block around line 341:
+```javascript
+document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach(input => {
+    input.addEventListener('change', () => {
+        if (input.name === 'title_variant') {
+            state.title = input.dataset.text;
+        } else if (input.name === 'fragment_variant') {
+            state.fragmentText = input.dataset.text;
+        } else if (input.name === 'url_variant') {
+            state.url = input.dataset.text;
+        } else if (input.name === 'favicon_option') {
+            state.faviconOption = input.value;
+        }
+        render();
+    });
+});
+```
+
+Replace with: Keep the `title_variant`, `fragment_variant`, and `url_variant` individual listeners (they're static and already work). Add a new delegated listener for `favicon_option` only:
+
+```javascript
+// Delegated listener — handles dynamically added pasted favicon radio
+document.getElementById('favicon-options').addEventListener('change', (e) => {
+    if (e.target.name === 'favicon_option') {
+        state.faviconOption = e.target.value;
+        render();
+    }
+});
+
+// Individual listeners for static radios
+document.querySelectorAll('input[name="title_variant"], input[name="fragment_variant"], input[name="url_variant"]').forEach(input => {
+    input.addEventListener('change', () => {
+        if (input.name === 'title_variant') {
+            state.title = input.dataset.text;
+        } else if (input.name === 'fragment_variant') {
+            state.fragmentText = input.dataset.text;
+        } else if (input.name === 'url_variant') {
+            state.url = input.dataset.text;
+        }
+        render();
+    });
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/mirror-links.html
+git commit -m "fix: delegate favicon_option change events to #favicon-options"
+```
+
+---
+
+## Task 3: Hide Redundant Non-HTML Previews
+
+**Files:**
+- Modify: `static/mirror.css`
+
+- [ ] **Step 1: Read the `link-format-row__plain` section of mirror.css**
+
+Locate the `.link-format-row__plain` rule around line 170.
+
+- [ ] **Step 2: Add CSS rule to hide display spans for non-HTML link rows**
+
+Add this rule after `.link-format-row__plain`:
+
+```css
+/* Only HTML link (first row) shows a visual preview.
+   Markdown/Wiki/Simple show only the raw text line. */
+.link-format-row:nth-child(n+2) .link-format-row__main > span:not(.variant-label):not(.btn-copy):not(.link-format-row__plain) {
+    display: none;
+}
+```
+
+Wait — `link-format-row__plain` is a sibling of `.link-format-row__main`, not a child. The selector needs to be simpler. The display span in each row is the `id="format-{format}-display"` span that is a direct child of `.link-format-row__main` alongside the button and label. These spans are plain text nodes.
+
+Better selector — use the `id` pattern or just target any span that is a direct child of `link-format-row__main` but is NOT the label or button:
+
+```css
+/* Hide the display preview for non-HTML link formats.
+   The first .link-format-row (HTML) shows a rendered link preview.
+   Markdown/Wiki/Simple show only the raw text line (in .link-format-row__plain below). */
+.link-format-row:nth-child(n+2) .link-format-row__main > span:not(.variant-label):not(.btn-copy) {
+    display: none;
+}
+```
+
+The selector `nth-child(n+2)` targets all `.link-format-row` elements from the 2nd onward. Within those, any plain `<span>` (not `.variant-label` and not `.btn-copy`) in the main row is hidden. The HTML row (1st) keeps its visual preview.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add static/mirror.css
+git commit -m "fix: hide redundant preview spans for non-HTML link formats"
+```
+
+---
+
+## Verification
+
+After all tasks, test manually:
+
+1. **Cookie wrapping:** Navigate to Mirror Links, paste HTML with a very long cookie string (`Cookie: 0x1234567890...` with 200+ chars). The string should wrap within the metadata panel rather than overflowing horizontally.
+
+2. **Pasted favicon:** Click "Paste Favicon", paste an image, verify the pasted favicon appears and is selected in the Links preview. Then click "URL", "None", or any other favicon option. Click the pasted favicon radio again — it should now properly switch back to pasted and update the link preview.
+
+3. **Non-HTML previews:** Observe the Links panel — only the HTML row should show a preview span above its raw text line. Markdown, Wiki-link, and Simple rows should show only the raw text line.
+
+Run: `make testv` to confirm no tests are broken.

--- a/docs/superpowers/specs/2026-04-18-mirror-links-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-04-18-mirror-links-bugfixes-design.md
@@ -1,0 +1,89 @@
+# Mirror Links Bug Fixes — Design
+
+**Date:** 2026-04-18
+**Type:** Bug fix
+**Status:** Approved
+
+## Overview
+
+Three independent UI fixes for the Mirror Links page:
+
+1. **Cookie string wrapping** — long cookie strings overflow the metadata panel
+2. **Pasted favicon re-selection** — clicking the pasted favicon radio after switching away never updates state
+3. **Non-HTML link previews** — Markdown/Wiki/Simple variants show redundant identical preview + raw text
+
+---
+
+## Fix 1: Cookie String Wrapping
+
+**Location:** `static/mirror.css` line 348, `.metadata-item`
+
+**Problem:** The `.metadata-item` rule has no text-wrapping property. Long strings (cookie strings, URLs, etc.) overflow the panel horizontally.
+
+**Change:**
+```css
+.metadata-item {
+    margin-bottom: var(--space-sm);
+    font-size: var(--font-size-sm);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+```
+
+`word-wrap` is the legacy name for `overflow-wrap`; both are included for maximum browser compatibility.
+
+---
+
+## Fix 2: Pasted Favicon Radio Button Event Handling
+
+**Location:** `templates/mirror-links.html` lines 340–354
+
+**Problem:** Radio change listeners are attached via `querySelectorAll` at `DOMContentLoaded` time. The pasted favicon radio is added **dynamically** by `addPastedFavicon()` in `paste-favicon.js` **after** page load, so it never receives a listener. The user can paste and see the pasted favicon initially, but cannot navigate back to it after selecting a different favicon option.
+
+**Solution:** Event delegation on the `#favicon-options` container, which exists at page load:
+
+```javascript
+// Old approach (lines 341-354):
+document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach(input => {
+    input.addEventListener('change', () => { ... });
+});
+
+// New approach — delegate to #favicon-options:
+document.getElementById('favicon-options').addEventListener('change', (e) => {
+    if (e.target.name === 'favicon_option') {
+        state.faviconOption = e.target.value;
+        render();
+    }
+});
+```
+
+This handles the pasted favicon radio (and any future dynamic radios) without any additional code.
+
+---
+
+## Fix 3: Non-HTML Link Variants — Raw Text Only
+
+**Location:** `templates/mirror-links.html` and `static/mirror.css`
+
+**Problem:** All four link format rows show both a "display" preview span and a raw text line below. For HTML, the display shows a rendered link (meaningful). For Markdown, Wiki-link, and Simple, the display is plain text identical to the raw text — purely redundant.
+
+**Solution:** CSS rule hides the display span for non-HTML rows:
+
+```css
+/* In .link-format-row__main, the display span is a plain text node
+   (not .variant-label or .btn-copy). Hide it for all but the first row. */
+.link-format-row:nth-child(n+2) .link-format-row__main > span:not(.variant-label):not(.btn-copy) {
+    display: none;
+}
+```
+
+The first `.link-format-row` (HTML) keeps its visual preview. All subsequent rows (Markdown, Wiki-link, Simple) show only the raw text line below.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `static/mirror.css` | Add `word-wrap` to `.metadata-item`; add `:nth-child` rule to hide non-HTML previews |
+| `templates/mirror-links.html` | Replace `querySelectorAll` radio loop with event delegation on `#favicon-options` |

--- a/static/mirror.css
+++ b/static/mirror.css
@@ -348,6 +348,8 @@ h1 {
 .metadata-item {
     margin-bottom: var(--space-sm);
     font-size: var(--font-size-sm);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .metadata-item strong {

--- a/static/mirror.css
+++ b/static/mirror.css
@@ -50,7 +50,7 @@ body {
 }
 
 .page-container {
-    max-width: 720px;
+    width: clamp(720px, 95%, 1600px);
     margin: 0 auto;
 }
 

--- a/static/mirror.css
+++ b/static/mirror.css
@@ -175,6 +175,13 @@ h1 {
     word-break: break-all;
 }
 
+/* Hide the display preview for non-HTML link formats.
+   The first .link-format-row (HTML) shows a rendered link preview.
+   Markdown/Wiki/Simple show only the raw text line (in .link-format-row__plain below). */
+.link-format-row:nth-child(n+2) .link-format-row__main > span:not(.variant-label):not(.btn-copy) {
+    display: none;
+}
+
 /* ============================================
    Copy Button
    ============================================ */

--- a/templates/mirror-links.html
+++ b/templates/mirror-links.html
@@ -337,8 +337,16 @@
                 }
             }, 100);
 
-            // Listen for changes to update state and render
-            document.querySelectorAll('input[type="radio"], input[type="checkbox"]').forEach(input => {
+            // Delegated listener — handles dynamically added pasted favicon radio
+            document.getElementById('favicon-options').addEventListener('change', (e) => {
+                if (e.target.name === 'favicon_option') {
+                    state.faviconOption = e.target.value;
+                    render();
+                }
+            });
+
+            // Individual listeners for static radios
+            document.querySelectorAll('input[name="title_variant"], input[name="fragment_variant"], input[name="url_variant"]').forEach(input => {
                 input.addEventListener('change', () => {
                     if (input.name === 'title_variant') {
                         state.title = input.dataset.text;
@@ -346,8 +354,6 @@
                         state.fragmentText = input.dataset.text;
                     } else if (input.name === 'url_variant') {
                         state.url = input.dataset.text;
-                    } else if (input.name === 'favicon_option') {
-                        state.faviconOption = input.value;
                     }
                     render();
                 });


### PR DESCRIPTION
## Summary
- CSS: enable `word-wrap: break-word` on metadata items so long cookie strings wrap instead of overflowing
- JS: delegate `favicon_option` change events to `#favicon-options` so dynamically added pasted favicon radio button is properly selectable after first paste
- CSS: hide redundant preview spans for non-HTML link formats (Markdown/Wiki/Simple) — only HTML shows a rendered preview

## Test Plan
- [ ] Long cookie strings wrap within metadata panel (not horizontal overflow)
- [ ] Paste favicon, switch to another favicon option, switch back — pasted favicon is properly selected and appears in links
- [ ] Mirror Links panel: only HTML row shows preview + raw text; Markdown/Wiki/Simple show raw text only
- [ ] All 328 tests pass