### PR TITLE
fix: remove invalid buildx version v1.0.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,6 @@ jobs:
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-        with:
-          version: v1.0.0
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- Remove invalid `version: v1.0.0` from docker/setup-buildx-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)