### PR TITLE
fix: remove GHA cache causing uv.lock cache key failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,6 @@ jobs:
           tags: |
             dockmann/web-tool:latest
             dockmann/web-tool:${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - uses: peter-evans/dockerhub-description@v5
         with:


### PR DESCRIPTION
## Summary
- Remove `cache-from: type=gha` and `cache-to: type=gha,mode=max` from docker/build-push-action
- The GHA cache backend was computing an invalid cache key for uv.lock, causing build failures

## Test plan
- [x] All 340 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)