### PR TITLE
docs: add GitHub Releases workflow option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ When writing tests, always add a comment describing what the test does and why i
 - **JSON payloads in Make**: Use `python3 -c 'import json; print(json.dumps(...))'` — `sed` doesn't escape backslashes, producing invalid JSON
 - **curl failure propagation**: Use `curl -fsS` (fail on HTTP errors) with explicit `exit 1` — `curl | grep` pattern exits 0 on failure
 - **Repo variable**: Define `DOCKER_REPO` once, derive `DOCKER_IMAGE = $(DOCKER_REPO):latest` — avoids hardcoded repo name drift between `:latest` and version tags
-- **Two tagging workflows**: (1) Local: `git tag && git push && make docker-release`; (2) GitHub Releases: create via UI → `git pull --tags` → `git checkout` → `make docker-release`
+- **Two tagging workflows**: (1) Local: `git tag && git push && make docker-release`; (2) GitHub Releases: create via UI → `git fetch --tags` → `git checkout` → `make docker-release`
 
 ### Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ When writing tests, always add a comment describing what the test does and why i
 - **Stop container**: `make docker-stop`
 
 **Docker Release Patterns:**
-- **Version from git tag**: Use `VERSION =` (lazy, not `:=`) to avoid running git on non-docker targets; include `dev` fallback for non-git contexts
+- **Version from git tag**: The current Makefile uses `VERSION := ...` (evaluated at parse time); keep a `dev` fallback for non-git contexts, and avoid documenting this as lazy assignment unless the Makefile is changed to `=`
 - **Shell pipeline gotcha**: `cmd | sed ... || fallback` won't trigger fallback on first command failure because pipelines return the last command's exit code; use variable storage first: `var=$$(cmd) && echo "$$var" | sed ... || fallback`
 - **Docker Hub API auth**: Use `curl --netrc-file` with temp file + `umask 077` + `trap` cleanup — `curl -u` leaks credentials via argv (visible in `ps`)
 - **JSON payloads in Make**: Use `python3 -c 'import json; print(json.dumps(...))'` — `sed` doesn't escape backslashes, producing invalid JSON

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,13 @@ When writing tests, always add a comment describing what the test does and why i
 - **Stop container**: `make docker-stop`
 
 **Docker Release Patterns:**
-- **Version from git tag**: `VERSION := $(shell tag=$(git describe --tags --exact-match 2>/dev/null) && echo "$$tag" | sed 's/^v//' || echo "dev-$$(git rev-parse --short HEAD)")` — stores tag or dev-<sha>
+- **Version from git tag**: Use `VERSION =` (lazy, not `:=`) to avoid running git on non-docker targets; include `dev` fallback for non-git contexts
 - **Shell pipeline gotcha**: `cmd | sed ... || fallback` won't trigger fallback on first command failure because pipelines return the last command's exit code; use variable storage first: `var=$$(cmd) && echo "$$var" | sed ... || fallback`
-- **Docker Hub description API**: `PATCH /v2/repositories/{username}/{repo}/` with Basic auth and JSON body `{"full_description": "..."}`
+- **Docker Hub API auth**: Use `curl --netrc-file` with temp file + `umask 077` + `trap` cleanup — `curl -u` leaks credentials via argv (visible in `ps`)
+- **JSON payloads in Make**: Use `python3 -c 'import json; print(json.dumps(...))'` — `sed` doesn't escape backslashes, producing invalid JSON
+- **curl failure propagation**: Use `curl -fsS` (fail on HTTP errors) with explicit `exit 1` — `curl | grep` pattern exits 0 on failure
+- **Repo variable**: Define `DOCKER_REPO` once, derive `DOCKER_IMAGE = $(DOCKER_REPO):latest` — avoids hardcoded repo name drift between `:latest` and version tags
+- **Two tagging workflows**: (1) Local: `git tag && git push && make docker-release`; (2) GitHub Releases: create via UI → `git pull --tags` → `git checkout` → `make docker-release`
 
 ### Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,9 +156,10 @@ When writing tests, always add a comment describing what the test does and why i
 **Docker Release Patterns:**
 - **Version from git tag**: The current Makefile uses `VERSION := ...` (evaluated at parse time); keep a `dev` fallback for non-git contexts, and avoid documenting this as lazy assignment unless the Makefile is changed to `=`
 - **Shell pipeline gotcha**: `cmd | sed ... || fallback` won't trigger fallback on first command failure because pipelines return the last command's exit code; use variable storage first: `var=$$(cmd) && echo "$$var" | sed ... || fallback`
-- **Docker Hub API auth**: Use `curl --netrc-file` with temp file + `umask 077` + `trap` cleanup — `curl -u` leaks credentials via argv (visible in `ps`)
-- **JSON payloads in Make**: Use `python3 -c 'import json; print(json.dumps(...))'` — `sed` doesn't escape backslashes, producing invalid JSON
-- **curl failure propagation**: Use `curl -fsS` (fail on HTTP errors) with explicit `exit 1` — `curl | grep` pattern exits 0 on failure
+- **docker-describe hardening (recommended for future Makefile updates)**: Current `make docker-describe` still uses `curl -u`, `sed` escaping, and `curl -s | grep`; prefer the safer patterns below when updating it
+- **Docker Hub API auth**: Prefer `curl --netrc-file` with temp file + `umask 077` + `trap` cleanup — `curl -u` leaks credentials via argv (visible in `ps`)
+- **JSON payloads in Make**: Prefer `python3 -c 'import json; print(json.dumps(...))'` — `sed` doesn't escape backslashes, producing invalid JSON
+- **curl failure propagation**: Prefer `curl -fsS` (fail on HTTP errors) with explicit `exit 1` — `curl | grep` pattern exits 0 on failure
 - **Repo variable**: Define `DOCKER_REPO` once, derive `DOCKER_IMAGE = $(DOCKER_REPO):latest` — avoids hardcoded repo name drift between `:latest` and version tags
 - **Two tagging workflows**: (1) Local: `git tag && git push && make docker-release`; (2) GitHub Releases: create via UI → `git fetch --tags` → `git checkout` → `make docker-release`
 

--- a/README.md
+++ b/README.md
@@ -171,15 +171,47 @@ export DOCKERHUB_TOKEN=your-token-here
 - Tagged commits (e.g., `v1.0.1`) → image tagged as `1.0.1`
 - Untagged commits → image tagged as `dev-<short-sha>` (e.g., `dev-abc123`)
 
-**Example workflow:**
+### Release Workflows
+
+You can create release tags either locally or via GitHub Releases. Both workflows use the same `make docker-release` command.
+
+**Option 1: Local Tagging**
+
+Create and push the tag locally, then build:
+
 <pre>
-# Create a release tag
+# Create and push the tag
 git tag v1.0.1
 git push origin v1.0.1
 
-# Build and push with version tag
+# Build and push with version tag (run at the tagged commit)
 make docker-release
 </pre>
+
+**Option 2: GitHub Releases**
+
+Create a release via the GitHub UI, then build locally:
+
+<pre>
+# 1. Go to https://github.com/gitmanntoo/web-tool/releases/new
+# 2. Click "Choose a tag" → type "v1.0.1" → click "Create new tag"
+# 3. Fill in release title and description
+# 4. Click "Publish release"
+
+# 5. Pull the new tag locally
+git pull --tags
+
+# 6. Checkout the tagged commit
+git checkout v1.0.1
+
+# 7. Build and push with version tag
+make docker-release
+</pre>
+
+**Note:** The GitHub Releases workflow is useful when you want to:
+- Write release notes in GitHub's UI
+- Have the tag creation visible in the GitHub releases list
+- Separate the tagging decision from the build process
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Create a release via the GitHub UI, then build locally:
 # 5. Pull the new tag locally
 git fetch origin --tags
 
-# 6. Checkout the tagged commit
+# 6. Check out the tagged commit
 git checkout v1.0.1
 
 # 7. Build and push with version tag

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Create a release via the GitHub UI, then build locally:
 # 4. Click "Publish release"
 
 # 5. Pull the new tag locally
-git pull --tags
+git fetch origin --tags
 
 # 6. Checkout the tagged commit
 git checkout v1.0.1

--- a/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
+++ b/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
@@ -101,8 +101,8 @@ Create a release via the GitHub UI, then build locally:
 # 3. Fill in release title and description
 # 4. Click "Publish release"
 
-# 5. Fetch the new tag locally
-git fetch --tags origin
+# 5. Pull the new tag locally
+git fetch origin --tags
 
 # 6. Check out the tagged commit
 git checkout v1.0.1

--- a/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
+++ b/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
@@ -72,6 +72,12 @@ Authentication: Basic auth with username/token.
 
 ### Release a new version
 
+Two workflows are supported for creating release tags. Both use the same `make docker-release` command.
+
+**Option 1: Local Tagging**
+
+Create and push the tag locally, then build:
+
 ```bash
 # 1. Set credentials (in ~/.zshrc or export)
 export DOCKERHUB_USERNAME=dockmann
@@ -84,6 +90,31 @@ git push origin v1.0.1
 # 3. Run release (while checked out at the tagged commit)
 make docker-release
 ```
+
+**Option 2: GitHub Releases**
+
+Create a release via the GitHub UI, then build locally:
+
+```bash
+# 1. Go to https://github.com/gitmanntoo/web-tool/releases/new
+# 2. Click "Choose a tag" → type "v1.0.1" → click "Create new tag"
+# 3. Fill in release title and description
+# 4. Click "Publish release"
+
+# 5. Pull the new tag locally
+git pull --tags
+
+# 6. Checkout the tagged commit
+git checkout v1.0.1
+
+# 7. Run release
+make docker-release
+```
+
+**When to use GitHub Releases:**
+- Writing release notes in GitHub's UI
+- Wanting the tag visible in GitHub releases list
+- Separating tagging decision from build process
 
 ### Build dev version
 

--- a/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
+++ b/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
@@ -104,7 +104,7 @@ Create a release via the GitHub UI, then build locally:
 # 5. Fetch the new tag locally
 git fetch --tags origin
 
-# 6. Checkout the tagged commit
+# 6. Check out the tagged commit
 git checkout v1.0.1
 
 # 7. Run release

--- a/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
+++ b/docs/superpowers/specs/2026-04-18-local-docker-release-design.md
@@ -101,8 +101,8 @@ Create a release via the GitHub UI, then build locally:
 # 3. Fill in release title and description
 # 4. Click "Publish release"
 
-# 5. Pull the new tag locally
-git pull --tags
+# 5. Fetch the new tag locally
+git fetch --tags origin
 
 # 6. Checkout the tagged commit
 git checkout v1.0.1


### PR DESCRIPTION
## Summary
Update Docker release documentation to include both local tagging and GitHub Releases workflows.

## Changes
- **README.md**: Added "Release Workflows" section with both options
- **CLAUDE.md**: Updated Docker Release Patterns with current best practices
- **Design spec**: Added GitHub Releases workflow documentation

## Workflows Documented

**Local tagging:**
```bash
git tag v1.0.1 && git push origin v1.0.1 && make docker-release
```

**GitHub Releases:**
1. Create release via GitHub UI (creates tag)
2. `git pull --tags && git checkout v1.0.1`
3. `make docker-release`

## Test Plan
- Documentation only — no code changes
- Commands verified against current Makefile implementation