### PR TITLE
fix: docker-describe sed error on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,9 @@ docker-describe:
 	@echo "  Source: README.md"
 	@echo ""
 	@NETRC_FILE=$$(mktemp); \
-	trap "rm -f $$NETRC_FILE" EXIT; \
 	umask 077; \
+	chmod 600 "$$NETRC_FILE"; \
+	trap "rm -f $$NETRC_FILE" EXIT; \
 	( echo "machine hub.docker.com"; \
 	  echo "login $(DOCKERHUB_USERNAME)"; \
 	  echo "password $(DOCKERHUB_TOKEN)" ) > "$$NETRC_FILE"; \

--- a/Makefile
+++ b/Makefile
@@ -178,13 +178,20 @@ docker-describe:
 	@echo "  Repository: $(DOCKERHUB_USERNAME)/web-tool"
 	@echo "  Source: README.md"
 	@echo ""
-	@DESCRIPTION=$$(cat README.md | sed 's/"/\\"/g' | sed ':a;N;$$!ba;s/\n/\\n/g'); \
-	curl -s -X PATCH \
+	@NETRC_FILE=$$(mktemp); \
+	trap "rm -f $$NETRC_FILE" EXIT; \
+	umask 077; \
+	( echo "machine hub.docker.com"; \
+	  echo "login $(DOCKERHUB_USERNAME)"; \
+	  echo "password $(DOCKERHUB_TOKEN)" ) > "$$NETRC_FILE"; \
+	DESCRIPTION=$$(python3 -c 'import json; print(json.dumps(open("README.md").read()))'); \
+	curl -fsS -X PATCH \
+		--netrc-file "$$NETRC_FILE" \
 		-H "Content-Type: application/json" \
-		-u "$(DOCKERHUB_USERNAME):$(DOCKERHUB_TOKEN)" \
-		-d "{\"full_description\": \"$$DESCRIPTION\"}" \
-		https://hub.docker.com/v2/repositories/$(DOCKERHUB_USERNAME)/web-tool/ \
-		| grep -q "full_description" && echo "Description updated successfully" || echo "Failed to update description (check credentials)"
+		-d "{\"full_description\": $$DESCRIPTION}" \
+		https://hub.docker.com/v2/repositories/$(DOCKERHUB_USERNAME)/web-tool/ && \
+	echo "Description updated successfully" || \
+	{ echo "Failed to update description (check credentials)"; exit 1; }
 
 # Stop running container
 docker-stop:


### PR DESCRIPTION
## Summary
Fixes the `make docker-describe` failure on macOS that occurred during the v2.0.1 release.

## Problem
The `docker-describe` target used `sed` for JSON escaping, which failed on macOS (BSD sed) with:
```
sed: 2: ":a;N;$!ba;s/\\n/\\n/g": unused label
```

Two issues:
1. Unescaped `$` in Make (`$!ba` interpreted as a variable reference)
2. BSD sed handles labels differently than GNU sed

## Changes
- **JSON escaping**: Use Python `json.dumps()` instead of sed (proper escaping for all special characters)
- **Credential security**: Replace `curl -u` with `--netrc-file` (prevents credential leakage via `ps`)
- **Error handling**: Add `-fsS` flags and explicit `exit 1` on failure
- **Cleanup**: Add `umask 077` and `trap` for secure temp file handling

## Testing
- `make -n docker-describe` exits 0 with no errors
- Python JSON escaping produces valid JSON strings
- All Make variables properly escaped with `$$`

Fixes the Docker Hub description update failure seen in the v2.0.1 release.