### PR TITLE
chore: enhance Docker Hub description reminder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,10 @@ When writing tests, always add a comment describing what the test does and why i
 - **Version from git tag**: Use `VERSION =` (lazy, not `:=`) to avoid running git on non-docker targets; include `dev` fallback for non-git contexts
 - **Shell pipeline gotcha**: `cmd | sed ... || fallback` won't trigger fallback on first command failure because pipelines return the last command's exit code; use variable storage first: `var=$$(cmd) && echo "$$var" | sed ... || fallback`
 - **Docker Hub description**: Updated manually via the Docker Hub UI after `make docker-release`
+- **Terminal reminder**: `make docker-release` displays a boxed reminder with manual update steps after a successful push
 - **Two tagging workflows**: (1) Local: `git tag && git push && make docker-release`; (2) GitHub Releases: create via UI → `git fetch origin --tags` → `git checkout` → `make docker-release`
+- **sed macOS compatibility**: Basic `sed 's/pattern/replacement/'` works on both GNU and BSD sed; only `sed -i` (in-place editing) requires macOS-specific handling
+- **Worktree file sync**: If changes exist in the main worktree before creating a new worktree, either stash them first or run `git checkout <branch> -- <file>` in the worktree to get the correct version before editing
 
 ### Git Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,9 @@ make docker-release
 
 ### Updating Docker Hub Description
 
-The Docker Hub description is no longer updated automatically. After pushing a release, update it manually:
+**Important:** The Docker Hub description is no longer updated automatically. After running `make docker-release`, the terminal will display a reminder with instructions.
+
+Update the Docker Hub description manually:
 
 1. Go to https://hub.docker.com/r/dockmann/web-tool
 2. Click the **Edit** button (pencil icon) next to the description

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ docker-release: docker-push
 	@echo "Latest: $(DOCKER_IMAGE)"
 	@echo ""
 	@echo "========================================"
-	@echo "  REMINDER: Manual Docker Hub Update  "
+	@echo "  REMINDER: Manual Docker Hub Update"
 	@echo "========================================"
 	@echo ""
 	@echo "The Docker Hub description is NOT updated automatically."

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,19 @@ docker-release: docker-push
 	@echo "Image: dockmann/web-tool:$(VERSION)"
 	@echo "Latest: $(DOCKER_IMAGE)"
 	@echo ""
-	@echo "NOTE: Docker Hub description not updated automatically."
-	@echo "      Update it manually at: https://hub.docker.com/r/dockmann/web-tool"
+	@echo "========================================"
+	@echo "  REMINDER: Manual Docker Hub Update  "
+	@echo "========================================"
+	@echo ""
+	@echo "The Docker Hub description is NOT updated automatically."
+	@echo ""
+	@echo "Steps to update:"
+	@echo "  1. Go to: https://hub.docker.com/r/dockmann/web-tool"
+	@echo "  2. Click the Edit (pencil) button next to the description"
+	@echo "  3. Paste the contents of README.md"
+	@echo "  4. Click Save"
+	@echo ""
+	@echo "========================================"
 
 # Stop running container
 docker-stop:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_IMAGE = dockmann/web-tool:latest
+DOCKER_REPO = $(firstword $(subst :, ,$(DOCKER_IMAGE)))
 
 # Docker Hub credentials (required for push operations)
 DOCKERHUB_USERNAME ?= $(shell echo $$DOCKERHUB_USERNAME)
@@ -157,17 +158,17 @@ docker-push:
 	docker buildx build \
 		--platform linux/amd64,linux/arm64 \
 		--tag $(DOCKER_IMAGE) \
-		--tag dockmann/web-tool:$(VERSION) \
+		--tag $(DOCKER_REPO):$(VERSION) \
 		--push .
 	@echo ""
 	@echo "Pushed: $(DOCKER_IMAGE)"
-	@echo "Pushed: dockmann/web-tool:$(VERSION)"
+	@echo "Pushed: $(DOCKER_REPO):$(VERSION)"
 
 # Full release: build and push multi-platform image with version tag
 docker-release: docker-push
 	@echo ""
 	@echo "=== Release Complete ==="
-	@echo "Image: dockmann/web-tool:$(VERSION)"
+	@echo "Image: $(DOCKER_REPO):$(VERSION)"
 	@echo "Latest: $(DOCKER_IMAGE)"
 	@echo ""
 	@echo "========================================"
@@ -177,7 +178,7 @@ docker-release: docker-push
 	@echo "The Docker Hub description is NOT updated automatically."
 	@echo ""
 	@echo "Steps to update:"
-	@echo "  1. Go to: https://hub.docker.com/r/dockmann/web-tool"
+	@echo "  1. Go to: https://hub.docker.com/r/$(DOCKER_REPO)"
 	@echo "  2. Click the Edit (pencil) button next to the description"
 	@echo "  3. Paste the contents of README.md"
 	@echo "  4. Click Save"


### PR DESCRIPTION
## Summary

Enhances the `docker-release` Makefile target to display a prominent, boxed reminder with step-by-step instructions for manually updating the Docker Hub description after pushing a release.

## Changes

- **Makefile** (lines 173-185): Replaced the two-line note with a formatted alert box that includes:
  - Clear visual separator
  - Explicit statement that the description is NOT updated automatically
  - Numbered steps with direct link to Docker Hub

## Why

The previous note was easy to miss in the terminal output. The new format makes it impossible to overlook the manual step required after each release.

## Testing

Run `make docker-release` (requires DOCKERHUB_USERNAME/TOKEN) to see the new reminder output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)